### PR TITLE
fix dry-run arg position in run_one

### DIFF
--- a/scripts/experiments/run_one.sh
+++ b/scripts/experiments/run_one.sh
@@ -68,8 +68,9 @@ ARGS=("--dataset" "$DATASET" "--model" "$MODEL" "--method" "$METHOD")
 if [[ -n "$BUDGET" ]]; then
   ARGS+=("--budget" "$BUDGET")
 fi
+GLOBAL_ARGS=()
 if [[ "${DRY_RUN}" == "1" ]]; then
-  ARGS+=("--dry-run")
+  GLOBAL_ARGS+=("--dry-run")
 fi
 
-python "${RKV_ROOT}/scripts/cli.py" run-one "${ARGS[@]}"
+python "${RKV_ROOT}/scripts/cli.py" "${GLOBAL_ARGS[@]}" run-one "${ARGS[@]}"


### PR DESCRIPTION
## fix --dry-run in script scripts/experiments/run_one.sh

This PR fixes the position of `--dry-run` when calling `scripts/experiments/run_one.sh --dry-run`. Must be global arg instead of subcommand arg.

### Usage

```bash
scripts/experiments/run_one.sh --dry-run
```