### PR TITLE
feat: DGX Spark port (GB10/sm-121) for vLLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,22 +105,7 @@ vllm serve <model_path> \
 
 ```bash
 pip install -e .
-pip install flash-attn --no-build-isolation  # recommended
-```
-
-### DGX Spark / GB10 installation
-
-```bash
-uv venv
-. .venv/bin/activate
-uv pip install --index-url https://download.pytorch.org/whl/cu130 torch torchvision torchaudio
-# Install this vLLM wheel first, even if you will not use vLLM now; it prevents dependency conflicts.
-uv pip install \
-  https://github.com/vllm-project/vllm/releases/download/v0.19.0/vllm-0.19.0-cp38-abi3-manylinux_2_31_aarch64.whl \
-  --extra-index-url https://download.pytorch.org/whl/cu130 \
-  --extra-index-url https://pypi.org/simple \
-  --index-strategy unsafe-best-match
-uv pip install -e .
+pip install flash-attn --no-build-isolation  # recommended (takes 105m in DGX Spark / GB10)
 ```
 
 ## Quick Start
@@ -191,11 +176,21 @@ curl http://localhost:8000/v1/chat/completions \
     -d '{"model": "<model_path>", "messages": [{"role": "user", "content": "Solve: ..."}]}'
 ```
 
-#### vLLM in DGX Spark / GB10
+#### vLLM with DGX Spark / GB10
 
-After completing the DGX Spark / GB10 and vLLM setup above, run:
+To enable vLLM in DGX Spark / GB10, run these installation steps instead:
 
 ```bash
+uv venv
+. .venv/bin/activate
+uv pip install --index-url https://download.pytorch.org/whl/cu130 torch torchvision torchaudio
+uv pip install \
+  https://github.com/vllm-project/vllm/releases/download/v0.19.0/vllm-0.19.0-cp38-abi3-manylinux_2_31_aarch64.whl \
+  --extra-index-url https://download.pytorch.org/whl/cu130 \
+  --extra-index-url https://pypi.org/simple \
+  --index-strategy unsafe-best-match
+uv pip install -e .
+
 export TRITON_CACHE_DIR=~/.cache/.triton-cache
 mkdir -p $TRITON_CACHE_DIR
 export LD_LIBRARY_PATH=./.venv/lib/python3.10/site-packages/torch/lib:./.venv/lib/python3.10/site-packages/nvidia/cu13/lib:/usr/local/lib/ollama/cuda_v12:/usr/local/cuda/targets/sbsa-linux/lib:${LD_LIBRARY_PATH:-}

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ vllm serve <model_path> \
 ## Installation
 
 ```bash
+git clone https://github.com/WeianMao/triattention.git
+cd triattention
 pip install -e .
 pip install flash-attn --no-build-isolation  # recommended (takes 105m in DGX Spark / GB10)
 ```
@@ -193,7 +195,9 @@ uv pip install -e .
 
 export TRITON_CACHE_DIR=~/.cache/.triton-cache
 mkdir -p $TRITON_CACHE_DIR
-export LD_LIBRARY_PATH=./.venv/lib/python3.10/site-packages/torch/lib:./.venv/lib/python3.10/site-packages/nvidia/cu13/lib:/usr/local/lib/ollama/cuda_v12:/usr/local/cuda/targets/sbsa-linux/lib:${LD_LIBRARY_PATH:-}
+
+PY_SITE=$(.venv/bin/python -c "import sysconfig; print(sysconfig.get_paths()['purelib'])")  # Or adjust as needed to your environment
+export LD_LIBRARY_PATH="$PY_SITE/torch/lib:$PY_SITE/nvidia/cu13/lib:/usr/local/cuda/targets/sbsa-linux/lib:${LD_LIBRARY_PATH:-}"
 
 vllm serve Qwen/Qwen3-8B \
   --dtype bfloat16 \

--- a/README.md
+++ b/README.md
@@ -104,10 +104,23 @@ vllm serve <model_path> \
 ## Installation
 
 ```bash
-git clone https://github.com/WeianMao/triattention.git
-cd triattention
 pip install -e .
 pip install flash-attn --no-build-isolation  # recommended
+```
+
+### DGX Spark / GB10 installation
+
+```bash
+uv venv
+. .venv/bin/activate
+uv pip install --index-url https://download.pytorch.org/whl/cu130 torch torchvision torchaudio
+# Install this vLLM wheel first, even if you will not use vLLM now; it prevents dependency conflicts.
+uv pip install \
+  https://github.com/vllm-project/vllm/releases/download/v0.19.0/vllm-0.19.0-cp38-abi3-manylinux_2_31_aarch64.whl \
+  --extra-index-url https://download.pytorch.org/whl/cu130 \
+  --extra-index-url https://pypi.org/simple \
+  --index-strategy unsafe-best-match
+uv pip install -e .
 ```
 
 ## Quick Start
@@ -164,7 +177,7 @@ TriAttention includes a vLLM plugin that enables transparent KV cache compressio
 export TRIATTN_RUNTIME_KV_BUDGET=2048
 export TRIATTN_RUNTIME_SPARSE_STATS_PATH=triattention/vllm/stats/qwen3_32b_int4_stats.pt
 
-# Launch vLLM server -- TriAttention activates automatically
+# Launch vLLM server -- TriAttention activates automatically. Set `ENABLE_TRIATTENTION=0` to disable.
 vllm serve <model_path> \
     --dtype bfloat16 \
     --max-model-len 32768 \
@@ -176,6 +189,30 @@ vllm serve <model_path> \
 curl http://localhost:8000/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{"model": "<model_path>", "messages": [{"role": "user", "content": "Solve: ..."}]}'
+```
+
+#### vLLM in DGX Spark / GB10
+
+After completing the DGX Spark / GB10 and vLLM setup above, run:
+
+```bash
+export TRITON_CACHE_DIR=~/.cache/.triton-cache
+mkdir -p $TRITON_CACHE_DIR
+export LD_LIBRARY_PATH=./.venv/lib/python3.10/site-packages/torch/lib:./.venv/lib/python3.10/site-packages/nvidia/cu13/lib:/usr/local/lib/ollama/cuda_v12:/usr/local/cuda/targets/sbsa-linux/lib:${LD_LIBRARY_PATH:-}
+
+vllm serve Qwen/Qwen3-8B \
+  --dtype bfloat16 \
+  --max-model-len 32768 \
+  --enforce-eager \
+  --trust-remote-code \
+  --no-enable-prefix-caching \
+  --gpu-memory-utilization 0.7
+```
+
+Verify the first vLLM log line is `[TriAttention] Runtime (V2) plugin activated: patch_scheduler=True patch_worker=True`.
+```bash
+curl http://127.0.0.1:8000/v1/models
+curl http://127.0.0.1:8000/v1/completions -H 'Content-Type: application/json' -d '{"model":"Qwen/Qwen3-8B","prompt":"hello","max_tokens":16}'
 ```
 
 ### Python API

--- a/triattention/methods/triattention.py
+++ b/triattention/methods/triattention.py
@@ -853,8 +853,12 @@ def apply_triattention_patch(
         if isinstance(pkv, Cache):
             if hasattr(pkv, 'to_legacy_cache'):
                 pkv_tuple = pkv.to_legacy_cache()
-            else:
+            elif hasattr(pkv, 'key_cache') and hasattr(pkv, 'value_cache'):
+                # Older cache API
                 pkv_tuple = tuple(zip(pkv.key_cache, pkv.value_cache))
+            else:
+                # Transformers >=5 cache API
+                pkv_tuple = tuple((layer[0], layer[1]) for layer in pkv)
         else:
             pkv_tuple = tuple(pkv) if pkv else ()
 
@@ -1012,7 +1016,13 @@ def apply_triattention_patch(
         if isinstance(outputs.past_key_values, Cache):
             if hasattr(DynamicCache, 'from_legacy_cache'):
                 new_cache = DynamicCache.from_legacy_cache(pkv_tuple)
+            elif hasattr(DynamicCache, 'update'):
+                # Transformers >=5 cache API
+                new_cache = DynamicCache()
+                for layer_idx, (k, v) in enumerate(pkv_tuple):
+                    new_cache.update(k, v, layer_idx)
             else:
+                # Older cache API
                 new_cache = DynamicCache()
                 for k, v in pkv_tuple:
                     new_cache.key_cache.append(k)

--- a/triattention/vllm/runtime/integration_monkeypatch.py
+++ b/triattention/vllm/runtime/integration_monkeypatch.py
@@ -358,7 +358,8 @@ def _patched_engine_core_step_with_batch_queue(self):
         exec_future = self.model_executor.execute_model(
             scheduler_output, non_block=True
         )
-        if not self.is_ec_producer:
+        # vLLM version compatibility: `is_ec_producer` exists in some versions and is missing in others. Default to False.
+        if not getattr(self, "is_ec_producer", False):
             model_executed = scheduler_output.total_num_scheduled_tokens > 0
 
         if self.is_pooling_model or not model_executed:


### PR DESCRIPTION
## TriAttention support on DGX Spark (GB10/sm-121) via vLLM

This PR enables TriAttention to run on DGX Spark and likely other GB10/sm-121 hardware using vLLM. The goal of this PR is functional enablement, allowing TriAttention to execute on these platforms and serve as a base for further performance tuning and experimentation on GB10. A follow-up PR will provide support without requiring vLLM as well.

### What's added

- **Enable vLLM + GB10** to run the TriAttention optimization
- **Updated installation instructions** to handle required dependencies. The latest CUDA / PyTorch libraries required for GB10 (sm-121) conflicted with the latest vLLM builds.

### Usage

```python
uv venv
. .venv/bin/activate

uv pip install --index-url https://download.pytorch.org/whl/cu130 torch torchvision torchaudio
uv pip install \
  https://github.com/vllm-project/vllm/releases/download/v0.19.0/vllm-0.19.0-cp38-abi3-manylinux_2_31_aarch64.whl \
  --extra-index-url https://download.pytorch.org/whl/cu130 \
  --extra-index-url https://pypi.org/simple \
  --index-strategy unsafe-best-match

uv pip install -e .

export TRITON_CACHE_DIR=~/.cache/.triton-cache
mkdir -p $TRITON_CACHE_DIR

export LD_LIBRARY_PATH=./.venv/lib/python3.10/site-packages/torch/lib:./.venv/lib/python3.10/site-packages/nvidia/cu13/lib:/usr/local/lib/ollama/cuda_v12:/usr/local/cuda/targets/sbsa-linux/lib:${LD_LIBRARY_PATH:-}

vllm serve Qwen/Qwen3-8B \
  --dtype bfloat16 \
  --max-model-len 32768 \
  --enforce-eager \
  --trust-remote-code \
  --no-enable-prefix-caching \
  --gpu-memory-utilization 0.7
```

### Hardware tested

- DGX Spark (GB10/sm-121): Qwen/Qwen3-8B, ~16 tok/s at budget=12000 (see notes below about performance)

### Notes

- This PR focuses on basic functionality, not performance optimization and TriAtrittion optimizations expected outcomes are not necessarily expected to be seen. I found 10% KV memory cache reduction with TriAttrition, more testing will come with the next PR that will also enable non-vLLM use on GB10.
- Parameters for vLLM used were as similar as possible when compared to non-GB10.
- GB10 is part of Blackwell architecture. No tests were performed on B200+ hardware.
- I think some of those changes were required as the original implementation was tested in A100 and H100 thus possibly using libraries versions that are not generally used with GB10.

---

Paper: https://arxiv.org/abs/2604.04921  
Fork: https://github.com/dscain/triattention