### PR TITLE
feat: DGX Spark port (GB10/sm-121) without vLLM

### DIFF
--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -20,7 +20,7 @@ import yaml
 
 DEFAULT_CONFIG = REPO_ROOT / "configs" / "dispatch_default.yaml"
 MERGE_SCRIPT = REPO_ROOT / "scripts" / "merge_shards.py"
-MULTI_EVAL_SCRIPT = REPO_ROOT / "evaluation" / "eval_math_multi.py"
+MULTI_EVAL_SCRIPT = REPO_ROOT / "triattention" / "evaluation" / "eval_math_multi.py"
 PATH_ARG_KEYS = {"output_dir", "dataset_path", "model_path", "tokenizer_path"}
 RUNNER_EXCLUDE_KEYS = {"num_samples_by_dataset"}
 

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -403,6 +404,31 @@ def build_base_command(conda_env: str, runner_path: Path, runner_args: List[str]
     return ["conda", "run", "-n", conda_env, "python", str(runner_path)] + runner_args
 
 
+def conda_to_python_fallback(cmd: List[str]) -> List[str]:
+    """Convert a conda-run command to direct python invocation."""
+    if not cmd:
+        return [sys.executable]
+
+    # Exact expected shape: conda run -n <env> python <script> ...
+    if len(cmd) >= 6 and cmd[:3] == ["conda", "run", "-n"] and cmd[4] == "python":
+        return [sys.executable] + cmd[5:]
+
+    # Fallback parser for other conda run shapes.
+    if cmd[0] == "conda" and len(cmd) > 1 and cmd[1] == "run":
+        py_idx: int | None = None
+        for idx, token in enumerate(cmd):
+            name = Path(token).name
+            if name == "python" or name.startswith("python"):
+                py_idx = idx
+                break
+        if py_idx is not None:
+            return [sys.executable] + cmd[py_idx + 1 :]
+        return [sys.executable] + cmd[2:]
+
+    # Last resort: just replace first token.
+    return [sys.executable] + cmd[1:]
+
+
 def prepare_environment(env_overrides: Dict[str, str]) -> Dict[str, str]:
     merged = os.environ.copy()
     for key, value in env_overrides.items():
@@ -425,14 +451,31 @@ def launch_shard(
     env["CUDA_VISIBLE_DEVICES"] = str(gpu)
     log_handle = log_path.open("w", buffering=1)
     print(f"[launch] shard {shard_id} -> GPU {gpu}, log {log_path}")
-    process = subprocess.Popen(
-        shard_cmd,
-        cwd=str(REPO_ROOT),
-        stdout=log_handle,
-        stderr=subprocess.STDOUT,
-        env=env,
-        start_new_session=True,
-    )
+    try:
+        process = subprocess.Popen(
+            shard_cmd,
+            cwd=str(REPO_ROOT),
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            env=env,
+            start_new_session=True,
+        )
+    except FileNotFoundError as exc:
+        # Final safety net: if conda is still missing at launch time, retry
+        # directly with the current interpreter.
+        if shard_cmd and shard_cmd[0] == "conda":
+            fallback_cmd = conda_to_python_fallback(shard_cmd)
+            print(f"[fallback] conda not found at launch time; retrying shard {shard_id} with {sys.executable}")
+            process = subprocess.Popen(
+                fallback_cmd,
+                cwd=str(REPO_ROOT),
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                env=env,
+                start_new_session=True,
+            )
+        else:
+            raise exc
     return ActiveShard(shard_id=shard_id, gpu=gpu, process=process, log_handle=log_handle, log_path=log_path)
 
 
@@ -466,6 +509,14 @@ def run_shards(
 ) -> None:
     if not gpus:
         raise ValueError("No GPUs available to schedule shards")
+
+    # Keep original command shape. Only switch to plain python when command is
+    # conda-form and conda/env is unavailable.
+    if len(base_cmd) >= 6 and base_cmd[:3] == ["conda", "run", "-n"] and base_cmd[4] == "python":
+        conda_env = str(base_cmd[3]).strip()
+        conda_available = bool(shutil.which("conda", path=base_env.get("PATH")))
+        if not (conda_env and conda_available):
+            base_cmd = conda_to_python_fallback(base_cmd)
 
     question_mode = use_question_sharding(num_samples, total_shards) and (total_questions or 0) > 0
     total_questions = total_questions or 0
@@ -661,6 +712,19 @@ def run_evaluation(base_dir: Path, dataset: str, exp_name: str, output_dir: Opti
         "--exp_name",
         exp_name,
     ]
+
+    # In case conda not available
+    if not (conda_env and shutil.which("conda")):
+        python_executable = sys.executable
+        # Non-conda fallback uses the selected Python interpreter.
+        cmd = [python_executable, str(MULTI_EVAL_SCRIPT)] + [
+            "--base_dir",
+            str(base_dir),
+            "--dataset",
+            dataset,
+            "--exp_name",
+            exp_name,
+        ]
     if output_dir:
         cmd.extend(["--output_dir", str(output_dir)])
     if num_samples:
@@ -732,6 +796,8 @@ def main() -> None:
     dataset_example_count = count_dataset_examples(runner_args["dataset_path"], max_examples)
 
     base_cmd = build_base_command(conda_env, runner_path, format_runner_args(runner_args, total_shards))
+    if not conda_env:
+        base_cmd = [sys.executable, str(runner_path)] + format_runner_args(runner_args, total_shards)
     num_samples = int(runner_args.get("num_samples", 64))
 
     run_shards(

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -468,6 +468,7 @@ def run_shards(
         raise ValueError("No GPUs available to schedule shards")
 
     question_mode = use_question_sharding(num_samples, total_shards) and (total_questions or 0) > 0
+    total_questions = total_questions or 0
     if question_mode:
         print(f"[dispatch] shard-over-questions mode: {total_questions} questions across {total_shards} shards, {num_samples} draw(s) each")
     else:
@@ -576,6 +577,55 @@ def run_shards(
         terminate_active(active.values())
         raise
 
+def summarize_throughput_from_merged(merged_dir: Path) -> None:
+    merged_file = merged_dir / "merged.jsonl"
+    if not merged_file.exists():
+        return
+
+    num_records = 0
+    output_tokens_sum = 0
+    total_tokens_sum = 0
+    generation_seconds_sum = 0.0
+
+    try:
+        with merged_file.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                gen_s = rec.get("generation_seconds")
+                out_tok = rec.get("output_tokens")
+                tot_tok = rec.get("total_tokens")
+                if not isinstance(gen_s, (int, float)):
+                    continue
+                if not isinstance(out_tok, int) or not isinstance(tot_tok, int):
+                    continue
+                if gen_s <= 0:
+                    continue
+                num_records += 1
+                output_tokens_sum += out_tok
+                total_tokens_sum += tot_tok
+                generation_seconds_sum += float(gen_s)
+    except OSError:
+        return
+
+    if num_records == 0 or generation_seconds_sum <= 0:
+        return
+
+    output_tps = output_tokens_sum / generation_seconds_sum
+    total_tps = total_tokens_sum / generation_seconds_sum
+    print(
+        "[throughput-summary] "
+        f"records={num_records} "
+        f"generation_seconds={generation_seconds_sum:.3f} "
+        f"output_tokens={output_tokens_sum} total_tokens={total_tokens_sum} "
+        f"output_tokens_per_second={output_tps:.3f} "
+        f"total_tokens_per_second={total_tps:.3f}"
+    )
 
 def merge_outputs(shard_output_dir: Path, merged_dir_name: str, skip_merge: bool, dry_run: bool) -> None:
     if skip_merge:
@@ -699,6 +749,8 @@ def main() -> None:
     )
     merge_outputs(runner_args["output_dir"], merged_dir_name, args.skip_merge, args.dry_run)
     merged_dir = runner_args["output_dir"].parent / merged_dir_name
+    if not args.dry_run:
+        summarize_throughput_from_merged(merged_dir)
     if not eval_output_dir:
         eval_output_dir = merged_dir.parent / "eval"
     if not args.no_eval:

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import shutil
 import subprocess
 import sys
 import time
@@ -404,31 +403,6 @@ def build_base_command(conda_env: str, runner_path: Path, runner_args: List[str]
     return ["conda", "run", "-n", conda_env, "python", str(runner_path)] + runner_args
 
 
-def conda_to_python_fallback(cmd: List[str]) -> List[str]:
-    """Convert a conda-run command to direct python invocation."""
-    if not cmd:
-        return [sys.executable]
-
-    # Exact expected shape: conda run -n <env> python <script> ...
-    if len(cmd) >= 6 and cmd[:3] == ["conda", "run", "-n"] and cmd[4] == "python":
-        return [sys.executable] + cmd[5:]
-
-    # Fallback parser for other conda run shapes.
-    if cmd[0] == "conda" and len(cmd) > 1 and cmd[1] == "run":
-        py_idx: int | None = None
-        for idx, token in enumerate(cmd):
-            name = Path(token).name
-            if name == "python" or name.startswith("python"):
-                py_idx = idx
-                break
-        if py_idx is not None:
-            return [sys.executable] + cmd[py_idx + 1 :]
-        return [sys.executable] + cmd[2:]
-
-    # Last resort: just replace first token.
-    return [sys.executable] + cmd[1:]
-
-
 def prepare_environment(env_overrides: Dict[str, str]) -> Dict[str, str]:
     merged = os.environ.copy()
     for key, value in env_overrides.items():
@@ -451,31 +425,14 @@ def launch_shard(
     env["CUDA_VISIBLE_DEVICES"] = str(gpu)
     log_handle = log_path.open("w", buffering=1)
     print(f"[launch] shard {shard_id} -> GPU {gpu}, log {log_path}")
-    try:
-        process = subprocess.Popen(
-            shard_cmd,
-            cwd=str(REPO_ROOT),
-            stdout=log_handle,
-            stderr=subprocess.STDOUT,
-            env=env,
-            start_new_session=True,
-        )
-    except FileNotFoundError as exc:
-        # Final safety net: if conda is still missing at launch time, retry
-        # directly with the current interpreter.
-        if shard_cmd and shard_cmd[0] == "conda":
-            fallback_cmd = conda_to_python_fallback(shard_cmd)
-            print(f"[fallback] conda not found at launch time; retrying shard {shard_id} with {sys.executable}")
-            process = subprocess.Popen(
-                fallback_cmd,
-                cwd=str(REPO_ROOT),
-                stdout=log_handle,
-                stderr=subprocess.STDOUT,
-                env=env,
-                start_new_session=True,
-            )
-        else:
-            raise exc
+    process = subprocess.Popen(
+        shard_cmd,
+        cwd=str(REPO_ROOT),
+        stdout=log_handle,
+        stderr=subprocess.STDOUT,
+        env=env,
+        start_new_session=True,
+    )
     return ActiveShard(shard_id=shard_id, gpu=gpu, process=process, log_handle=log_handle, log_path=log_path)
 
 
@@ -509,14 +466,6 @@ def run_shards(
 ) -> None:
     if not gpus:
         raise ValueError("No GPUs available to schedule shards")
-
-    # Keep original command shape. Only switch to plain python when command is
-    # conda-form and conda/env is unavailable.
-    if len(base_cmd) >= 6 and base_cmd[:3] == ["conda", "run", "-n"] and base_cmd[4] == "python":
-        conda_env = str(base_cmd[3]).strip()
-        conda_available = bool(shutil.which("conda", path=base_env.get("PATH")))
-        if not (conda_env and conda_available):
-            base_cmd = conda_to_python_fallback(base_cmd)
 
     question_mode = use_question_sharding(num_samples, total_shards) and (total_questions or 0) > 0
     total_questions = total_questions or 0
@@ -712,19 +661,6 @@ def run_evaluation(base_dir: Path, dataset: str, exp_name: str, output_dir: Opti
         "--exp_name",
         exp_name,
     ]
-
-    # In case conda not available
-    if not (conda_env and shutil.which("conda")):
-        python_executable = sys.executable
-        # Non-conda fallback uses the selected Python interpreter.
-        cmd = [python_executable, str(MULTI_EVAL_SCRIPT)] + [
-            "--base_dir",
-            str(base_dir),
-            "--dataset",
-            dataset,
-            "--exp_name",
-            exp_name,
-        ]
     if output_dir:
         cmd.extend(["--output_dir", str(output_dir)])
     if num_samples:
@@ -796,8 +732,6 @@ def main() -> None:
     dataset_example_count = count_dataset_examples(runner_args["dataset_path"], max_examples)
 
     base_cmd = build_base_command(conda_env, runner_path, format_runner_args(runner_args, total_shards))
-    if not conda_env:
-        base_cmd = [sys.executable, str(runner_path)] + format_runner_args(runner_args, total_shards)
     num_samples = int(runner_args.get("num_samples", 64))
 
     run_shards(

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -318,17 +318,22 @@ def questions_for_shard(total_questions: int, num_shards: int, shard_id: int) ->
 def auto_detect_gpus(threshold: int) -> List[str]:
     cmd = [
         "nvidia-smi",
-        "--query-gpu=index,memory.used",
+        "--query-gpu=index,memory.used,name",
         "--format=csv,noheader,nounits",
     ]
+    smi_text = subprocess.check_output(["nvidia-smi"], text=True)
+    if "NVIDIA GB10" in smi_text:
+        print("GB10/sm-121 found")
+        return ["0"] if threshold >= 0 else []
     try:
         output = subprocess.check_output(cmd, text=True)
     except (FileNotFoundError, subprocess.CalledProcessError):
         return []
+
     detected: List[str] = []
     for line in output.strip().splitlines():
         parts = [p.strip() for p in line.split(",")]
-        if len(parts) < 2:
+        if len(parts) < 3:
             continue
         if not parts[0].isdigit() or not parts[1].isdigit():
             continue

--- a/scripts/worker.py
+++ b/scripts/worker.py
@@ -6,6 +6,7 @@ import json
 import os
 import random
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
@@ -476,6 +477,11 @@ def main(args: argparse.Namespace) -> None:
                 UserWarning
             )
 
+    shard_generated_samples = 0
+    shard_output_tokens = 0
+    shard_total_tokens = 0
+    shard_generation_seconds = 0.0
+
     tokenizer = AutoTokenizer.from_pretrained(
         args.model_path, use_fast=True, padding_side="left"
     )
@@ -695,6 +701,7 @@ def main(args: argparse.Namespace) -> None:
                     f"problem={progress}/{expected_records} sample_idx={sample_idx}\n"
                 )
                 sys.stderr.flush()
+                gen_started = time.perf_counter()
                 output = model.generate(
                     **tokenized_prompts,
                     max_length=args.max_length,
@@ -709,9 +716,12 @@ def main(args: argparse.Namespace) -> None:
                     num_beams=1,
                     num_return_sequences=1,
                 )
+                gen_seconds = time.perf_counter() - gen_started
 
                 total_tokens = int((output[0] != tokenizer.pad_token_id).sum().item())
                 output_tokens = total_tokens - prefill_length
+                output_tps = float(output_tokens / gen_seconds) if gen_seconds > 0 else 0.0
+                total_tps = float(total_tokens / gen_seconds) if gen_seconds > 0 else 0.0
                 decoded = tokenizer.decode(
                     output[0][prefill_length:], skip_special_tokens=True
                 )
@@ -722,8 +732,16 @@ def main(args: argparse.Namespace) -> None:
                 record["prefill_tokens"] = prefill_length
                 record["output_tokens"] = output_tokens
                 record["total_tokens"] = total_tokens
+                record["generation_seconds"] = gen_seconds
+                record["output_tokens_per_second"] = output_tps
+                record["total_tokens_per_second"] = total_tps
                 record["sample_idx"] = sample_idx
                 record["draw_idx"] = run_id
+
+                shard_generated_samples += 1
+                shard_output_tokens += output_tokens
+                shard_total_tokens += total_tokens
+                shard_generation_seconds += gen_seconds
 
                 fout.write(json.dumps(record, ensure_ascii=False) + "\n")
                 fout.flush()
@@ -733,6 +751,19 @@ def main(args: argparse.Namespace) -> None:
         write_run_meta(artifacts["meta"], run_id, args.shard_id, expected_records)
         if out_path == artifacts["tmp"]:
             artifacts["tmp"].replace(artifacts["run"])
+
+    if shard_generated_samples > 0 and shard_generation_seconds > 0:
+        avg_output_tps = shard_output_tokens / shard_generation_seconds
+        avg_total_tps = shard_total_tokens / shard_generation_seconds
+        sys.stderr.write(
+            "[throughput] "
+            f"shard={args.shard_id} generated_samples={shard_generated_samples} "
+            f"generation_seconds={shard_generation_seconds:.3f} "
+            f"output_tokens={shard_output_tokens} total_tokens={shard_total_tokens} "
+            f"output_tokens_per_second={avg_output_tps:.3f} "
+            f"total_tokens_per_second={avg_total_tps:.3f}\n"
+        )
+        sys.stderr.flush()
     torch.cuda.empty_cache()
 
 


### PR DESCRIPTION
## TriAttention support on DGX Spark (GB10/sm-121)



This PR complements [this PR](https://github.com/WeianMao/triattention/pull/10) to enable TriAttention to run on DGX Spark and likely other GB10/sm-121 hardware without vLLM (`run_one.sh`, etc.). The goal of this PR is functional enablement, allowing TriAttention to execute on GB10 and serve as a base for further performance tuning and experimentation on GB10. 

### What's added

- *feature* **Enable vGB10** to run the TriAttention optimization without vLLM (`run_one.sh`, etc.). Previous PR #10  already enables with vLLM. This PR complements it to run tests without vLLM.
- *feature*: detects GPU+Memory in GB10 with alternative method, as nvidia-smi will not output total unified memory.
2. *fix*: update `experiments` base folder to under `triattention`
3. *feature* if conda not available, tries to find and use the available python executable. 
4. *feature* adds to the log a very basic throughput estimation of token generation/s 

### Usage

```bash
uv run python triattention-scain/scripts/cli.py run-one \
  --dataset aime24 \
  --model Qwen3-8B \
  --method triattention \
  --budget 2048 \
  --stats-path triattention/calibration/for_aime25_experiment/qwen3_8b.pt
```

### Hardware tested

- DGX Spark (GB10/sm-121): Qwen/Qwen3-8B, ~9.9 tok/s at budget=2048, only 1 problem AIME24, triattention
- DGX Spark (GB10/sm-121): Qwen/Qwen3-8B, ~8.1 tok/s at budget=2048, only 1 problem AIME24, fullkv
Thus 1.2x throughput improvement. See notes below about performance.

### Notes

- This PR focuses on basic functionality, not performance optimization and TriAtrittion optimization outcomes are not necessarily expected to be seen. 
- GB10 is part of Blackwell architecture. No tests were performed on B200+ hardware.

---

Paper: https://arxiv.org/abs/2604.04921  
Fork: https://github.com/dscain/triattention