### PR TITLE
gemma4: mixed-head calibration via flash-attn/SDPA hybrid attention; SGLang and vLLM runner paths

### DIFF
--- a/triattention/sglang/scoring_utils.py
+++ b/triattention/sglang/scoring_utils.py
@@ -127,11 +127,18 @@ def score_layer_hf_aligned(
         )
 
     # Slice stats to local shard's attention heads.
-    q_mean_complex_local = layer_stats_full["q_mean_complex"][head_start:head_end]
-    q_abs_mean_local = layer_stats_full["q_abs_mean"][head_start:head_end]
+    runtime_freq_count = int(layer_k.shape[-1]) // 2
+    if runtime_freq_count <= 0:
+        raise RuntimeError("invalid_runtime_head_dim")
+    q_mean_complex_local = layer_stats_full["q_mean_complex"][
+        head_start:head_end, :runtime_freq_count, :
+    ].contiguous()
+    q_abs_mean_local = layer_stats_full["q_abs_mean"][
+        head_start:head_end, :runtime_freq_count
+    ].contiguous()
 
     # freq_scale_sq is shared across heads -- expand to local head count.
-    freq_scale_sq_1d = layer_stats_full["freq_scale_sq"]  # [freq_count]
+    freq_scale_sq_1d = layer_stats_full["freq_scale_sq"][:runtime_freq_count]  # [freq_count]
     freq_scale_sq_expanded = freq_scale_sq_1d.unsqueeze(0).expand(
         num_attention_heads_local, -1
     ).contiguous()
@@ -148,7 +155,7 @@ def score_layer_hf_aligned(
         key_states=layer_k_expanded,
         cache_positions=None,
         head_stats=head_stats_for_scoring,
-        omega=compressor.omega,
+        omega=compressor.omega[:runtime_freq_count],
         offsets=compressor.offsets,
         freq_scale_sq=freq_scale_sq_expanded,
         config=compressor.config,

--- a/triattention/sglang/stats_loader.py
+++ b/triattention/sglang/stats_loader.py
@@ -93,6 +93,11 @@ class StatsBundle:
         return self.head_dim // 2
 
     @property
+    def layer_freq_counts(self) -> list[int]:
+        raw = self.metadata.get("layer_freq_counts", [])
+        return [int(x) for x in raw] if isinstance(raw, (list, tuple)) else []
+
+    @property
     def rope_style(self) -> str:
         return str(self.metadata.get("rope_style", "half"))
 
@@ -171,8 +176,31 @@ def load_stats(
 
     num_layers = len(layer_nums)
     num_attention_heads = len(head_nums)
-    head_dim = rkv_metadata.get("head_dim", 128)
-    freq_count = head_dim // 2
+    layer_head_dims_raw = rkv_metadata.get("layer_head_dims")
+    layer_head_dims = (
+        {int(i): int(v) for i, v in enumerate(layer_head_dims_raw)}
+        if isinstance(layer_head_dims_raw, (list, tuple))
+        else {}
+    )
+
+    def _entry_freq_count(layer_idx: int) -> int:
+        for head_idx in sorted(head_nums):
+            entry = rkv_stats_raw.get(f"layer{layer_idx:02d}_head{head_idx:02d}")
+            if not isinstance(entry, dict):
+                continue
+            for stat_name in ("q_abs_mean", "q_mean_real", "q_mean_imag"):
+                value = entry.get(stat_name)
+                if isinstance(value, torch.Tensor):
+                    return int(value.numel())
+        if layer_idx in layer_head_dims:
+            return max(1, int(layer_head_dims[layer_idx]) // 2)
+        return int(rkv_metadata.get("head_dim", 128)) // 2
+
+    layer_freq_counts = {
+        int(layer_idx): _entry_freq_count(int(layer_idx)) for layer_idx in layer_nums
+    }
+    freq_count = max(layer_freq_counts.values()) if layer_freq_counts else 64
+    head_dim = max(int(rkv_metadata.get("head_dim", freq_count * 2)), freq_count * 2)
 
     # Compute GQA group size (do NOT aggregate)
     effective_num_kv_heads = num_kv_heads if num_kv_heads else num_attention_heads
@@ -241,6 +269,22 @@ def load_stats(
             pass
     if freq_scale_sq is None:
         freq_scale_sq = torch.ones(freq_count, device=device, dtype=torch.float32)
+    elif freq_scale_sq.numel() < freq_count:
+        padded = torch.ones(freq_count, device=device, dtype=torch.float32)
+        padded[: freq_scale_sq.numel()] = freq_scale_sq.flatten()
+        freq_scale_sq = padded
+    else:
+        freq_scale_sq = freq_scale_sq.flatten()[:freq_count].contiguous()
+
+    def _pad_1d(value: torch.Tensor, target: int, *, fill: float = 0.0) -> torch.Tensor:
+        value = value.flatten()
+        if value.numel() == target:
+            return value
+        if value.numel() > target:
+            return value[:target]
+        out = torch.full((target,), fill, device=value.device, dtype=value.dtype)
+        out[: value.numel()] = value
+        return out
 
     # --- build per-layer stats at attention-head granularity ---
     # Each layer stores tensors with dim-0 = num_attention_heads
@@ -251,6 +295,7 @@ def load_stats(
         all_q_mean_real = []
         all_q_mean_imag = []
         all_q_abs_mean = []
+        layer_freq_count = int(layer_freq_counts.get(layer_idx, freq_count))
 
         for head_idx in sorted(head_nums):
             key = f"layer{layer_idx:02d}_head{head_idx:02d}"
@@ -258,7 +303,11 @@ def load_stats(
                 head_data = rkv_stats_raw[key]
                 if "q_abs_mean" in head_data:
                     all_q_abs_mean.append(
-                        head_data["q_abs_mean"].to(device=device, dtype=torch.float32)
+                        _pad_1d(
+                            head_data["q_abs_mean"].to(device=device, dtype=torch.float32),
+                            freq_count,
+                            fill=1.0,
+                        )
                     )
                 else:
                     all_q_abs_mean.append(
@@ -266,19 +315,26 @@ def load_stats(
                     )
                 if "q_mean_real" in head_data and "q_mean_imag" in head_data:
                     all_q_mean_real.append(
-                        head_data["q_mean_real"].to(device=device, dtype=torch.float32)
+                        _pad_1d(
+                            head_data["q_mean_real"].to(device=device, dtype=torch.float32),
+                            freq_count,
+                        )
                     )
                     all_q_mean_imag.append(
-                        head_data["q_mean_imag"].to(device=device, dtype=torch.float32)
+                        _pad_1d(
+                            head_data["q_mean_imag"].to(device=device, dtype=torch.float32),
+                            freq_count,
+                        )
                     )
 
         # Stack all attention heads WITHOUT GQA aggregation.
         # Shape: [num_attention_heads, freq_count]
         q_abs_mean_stacked = torch.stack(all_q_abs_mean, dim=0)
 
-        layer_entry: Dict[str, torch.Tensor] = {
+        layer_entry: Dict[str, Any] = {
             "freq_scale_sq": freq_scale_sq.clone(),  # [freq_count] (shared)
             "q_abs_mean": q_abs_mean_stacked,  # [num_attention_heads, freq_count]
+            "freq_count": layer_freq_count,
         }
 
         if all_q_mean_real and all_q_mean_imag:
@@ -297,6 +353,14 @@ def load_stats(
         "num_kv_heads": effective_num_kv_heads,
         "head_dim": head_dim,
         "num_layers": num_layers,
+        "layer_head_dims": [
+            int(layer_head_dims.get(layer_idx, layer_freq_counts.get(layer_idx, freq_count) * 2))
+            for layer_idx in range(num_layers)
+        ],
+        "layer_freq_counts": [
+            int(layer_freq_counts.get(layer_idx, freq_count))
+            for layer_idx in range(num_layers)
+        ],
         "rope_style": rkv_metadata.get("rope_style", "half"),
         "rope_type": rkv_metadata.get("rope_type"),
         "rope_theta": rkv_metadata.get("rope_theta", 10000.0),
@@ -352,7 +416,17 @@ def validate_stats_against_model(
     """
     errors = []
 
-    if bundle.head_dim != model_head_dim:
+    layer_head_dims_raw = bundle.metadata.get("layer_head_dims", [])
+    layer_head_dims = (
+        [int(x) for x in layer_head_dims_raw]
+        if isinstance(layer_head_dims_raw, (list, tuple))
+        else []
+    )
+    model_head_dims = {int(model_head_dim)}
+    if layer_head_dims:
+        model_head_dims.add(max(layer_head_dims))
+
+    if bundle.head_dim not in model_head_dims:
         errors.append(
             f"head_dim mismatch: stats={bundle.head_dim}, "
             f"model={model_head_dim}"
@@ -394,10 +468,14 @@ def validate_stats_against_model(
     # Accept if tensor dim-0 == model_num_kv_heads (aggregated) or is
     # a multiple of model_num_kv_heads (attention-head granularity).
     for layer_idx, layer_data in bundle.head_stats.items():
+        expected_freq = (
+            int(layer_head_dims[layer_idx]) // 2
+            if layer_idx < len(layer_head_dims)
+            else int(model_head_dim) // 2
+        )
         q_mean = layer_data.get("q_mean_complex")
         if q_mean is not None:
             actual_heads = q_mean.shape[0]
-            expected_freq = model_head_dim // 2
             if actual_heads != model_num_kv_heads and (
                 actual_heads == 0 or model_num_kv_heads == 0
                 or actual_heads % model_num_kv_heads != 0
@@ -407,23 +485,22 @@ def validate_stats_against_model(
                     f"{actual_heads} incompatible with model KV heads "
                     f"{model_num_kv_heads}"
                 )
-            if q_mean.shape[-2] != expected_freq or q_mean.shape[-1] != 2:
+            if q_mean.shape[-2] < expected_freq or q_mean.shape[-1] != 2:
                 errors.append(
                     f"layer {layer_idx} q_mean_complex shape "
                     f"{tuple(q_mean.shape)} has wrong freq/complex dims "
-                    f"(expected [*, {expected_freq}, 2])"
+                    f"(expected at least [*, {expected_freq}, 2])"
                 )
 
         freq_sq = layer_data.get("freq_scale_sq")
         if freq_sq is not None:
             # freq_scale_sq can be 1D [freq_count] (shared)
             # or 2D [num_heads, freq_count].
-            expected_freq = model_head_dim // 2
             if freq_sq.dim() == 1:
-                if freq_sq.shape[0] != expected_freq:
+                if freq_sq.shape[0] < expected_freq:
                     errors.append(
                         f"layer {layer_idx} freq_scale_sq dim "
-                        f"{freq_sq.shape[0]} != expected {expected_freq}"
+                        f"{freq_sq.shape[0]} < expected {expected_freq}"
                     )
             else:
                 actual_heads = freq_sq.shape[0]
@@ -436,10 +513,10 @@ def validate_stats_against_model(
                         f"{actual_heads} incompatible with model KV heads "
                         f"{model_num_kv_heads}"
                     )
-                if freq_sq.shape[-1] != expected_freq:
+                if freq_sq.shape[-1] < expected_freq:
                     errors.append(
                         f"layer {layer_idx} freq_scale_sq freq dim "
-                        f"{freq_sq.shape[-1]} != expected {expected_freq}"
+                        f"{freq_sq.shape[-1]} < expected {expected_freq}"
                     )
         # Only check the first layer with stats to avoid verbose output.
         break

--- a/triattention/tests/test_gemma4_mixed_head_stats.py
+++ b/triattention/tests/test_gemma4_mixed_head_stats.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+import torch
+
+from triattention.sglang.stats_loader import (
+    load_stats,
+    validate_stats_against_model,
+)
+from triattention.vllm.core.utils import load_frequency_stats
+
+
+def _gemma4_like_payload() -> dict:
+    stats = {}
+    for layer_idx, freq_count in [(0, 128), (1, 256)]:
+        for head_idx in range(4):
+            value = float(layer_idx + head_idx + 1)
+            stats[f"layer{layer_idx:02d}_head{head_idx:02d}"] = {
+                "q_mean_real": torch.full((freq_count,), value),
+                "q_mean_imag": torch.full((freq_count,), value + 0.5),
+                "q_abs_mean": torch.full((freq_count,), value + 1.0),
+            }
+    return {
+        "metadata": {
+            "head_dim": 512,
+            "layer_head_dims": [256, 512],
+            "num_key_value_heads": 2,
+            "rope_style": "half",
+            "rope_theta": 10000.0,
+        },
+        "stats": stats,
+    }
+
+
+def test_vllm_rkv_loader_handles_gemma4_mixed_head_dims(tmp_path: Path) -> None:
+    path = tmp_path / "gemma4_stats.pt"
+    torch.save(_gemma4_like_payload(), path)
+
+    metadata, head_stats = load_frequency_stats(
+        path,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+
+    assert metadata["head_dim"] == 512
+    assert metadata["num_kv_heads"] == 2
+    assert metadata["layer_head_dims"] == [256, 512]
+    assert metadata["layer_freq_counts"] == [128, 256]
+
+    assert head_stats[0]["q_mean_complex"].shape == (2, 256, 2)
+    assert head_stats[1]["q_mean_complex"].shape == (2, 256, 2)
+    assert torch.all(head_stats[0]["q_mean_complex"][:, 128:, :] == 0)
+    assert torch.all(head_stats[0]["q_abs_mean"][:, 128:] == 1)
+
+
+def test_sglang_rkv_loader_handles_gemma4_mixed_head_dims(tmp_path: Path) -> None:
+    path = tmp_path / "gemma4_stats.pt"
+    torch.save(_gemma4_like_payload(), path)
+
+    bundle = load_stats(
+        str(path),
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+        num_kv_heads=2,
+    )
+
+    assert bundle.head_dim == 512
+    assert bundle.num_kv_heads == 2
+    assert bundle.num_attention_heads == 4
+    assert bundle.gqa_group_size == 2
+    assert bundle.layer_freq_counts == [128, 256]
+
+    assert bundle.head_stats[0]["q_mean_complex"].shape == (4, 256, 2)
+    assert bundle.head_stats[1]["q_mean_complex"].shape == (4, 256, 2)
+    assert torch.all(bundle.head_stats[0]["q_mean_complex"][:, 128:, :] == 0)
+    assert torch.all(bundle.head_stats[0]["q_abs_mean"][:, 128:] == 1)
+
+    validate_stats_against_model(
+        bundle,
+        model_num_layers=2,
+        model_num_kv_heads=2,
+        model_head_dim=256,
+    )
+    validate_stats_against_model(
+        bundle,
+        model_num_layers=2,
+        model_num_kv_heads=2,
+        model_head_dim=512,
+    )

--- a/triattention/vllm/core/utils.py
+++ b/triattention/vllm/core/utils.py
@@ -172,12 +172,39 @@ def _convert_rkv_stats(
 
     num_layers = len(layer_nums)
     num_attention_heads = len(head_nums)
-    head_dim = rkv_metadata.get("head_dim", 128)
-    freq_count = head_dim // 2
+    layer_head_dims_raw = rkv_metadata.get("layer_head_dims")
+    layer_head_dims = (
+        {int(i): int(v) for i, v in enumerate(layer_head_dims_raw)}
+        if isinstance(layer_head_dims_raw, (list, tuple))
+        else {}
+    )
+
+    def _entry_freq_count(layer_idx: int) -> int:
+        for head_idx in sorted(head_nums):
+            entry = rkv_stats.get(f"layer{layer_idx:02d}_head{head_idx:02d}")
+            if not isinstance(entry, dict):
+                continue
+            for stat_name in ("q_abs_mean", "q_mean_real", "q_mean_imag"):
+                value = entry.get(stat_name)
+                if isinstance(value, torch.Tensor):
+                    return int(value.numel())
+        if layer_idx in layer_head_dims:
+            return max(1, layer_head_dims[layer_idx] // 2)
+        return int(rkv_metadata.get("head_dim", 128)) // 2
+
+    layer_freq_counts = {
+        int(layer_idx): _entry_freq_count(int(layer_idx)) for layer_idx in layer_nums
+    }
+    freq_count = max(layer_freq_counts.values()) if layer_freq_counts else 64
+    head_dim = max(int(rkv_metadata.get("head_dim", freq_count * 2)), freq_count * 2)
 
     # Handle GQA: if num_kv_heads specified and < num_attention_heads
     if num_kv_heads is None:
-        num_kv_heads = num_attention_heads
+        meta_kv_heads = rkv_metadata.get(
+            "num_kv_heads",
+            rkv_metadata.get("num_key_value_heads"),
+        )
+        num_kv_heads = int(meta_kv_heads) if meta_kv_heads else num_attention_heads
 
     gqa_ratio = num_attention_heads // num_kv_heads if num_kv_heads > 0 else 1
 
@@ -233,6 +260,14 @@ def _convert_rkv_stats(
         "num_kv_heads": num_kv_heads,
         "head_dim": head_dim,
         "num_layers": num_layers,
+        "layer_head_dims": [
+            int(layer_head_dims.get(layer_idx, layer_freq_counts.get(layer_idx, freq_count) * 2))
+            for layer_idx in range(num_layers)
+        ],
+        "layer_freq_counts": [
+            int(layer_freq_counts.get(layer_idx, freq_count))
+            for layer_idx in range(num_layers)
+        ],
         "rope_style": rkv_metadata.get("rope_style", "half"),
         "rope_type": rkv_metadata.get("rope_type"),
         "rope_theta": rkv_metadata.get("rope_theta", 10000.0),
@@ -295,11 +330,23 @@ def _convert_rkv_stats(
         )
 
     default_freq_scale_sq = _derive_freq_scale_sq_fallback()
+
+    def _pad_1d(value: torch.Tensor, target: int, *, fill: float = 0.0) -> torch.Tensor:
+        value = value.flatten()
+        if value.numel() == target:
+            return value
+        if value.numel() > target:
+            return value[:target]
+        out = torch.full((target,), fill, dtype=value.dtype)
+        out[: value.numel()] = value
+        return out
+
     for layer_idx in sorted(layer_nums):
         # Collect all attention heads' data for this layer
         all_q_mean_real = []
         all_q_mean_imag = []
         all_q_abs_mean = []
+        layer_freq_count = int(layer_freq_counts.get(layer_idx, freq_count))
 
         for head_idx in sorted(head_nums):
             key = f"layer{layer_idx:02d}_head{head_idx:02d}"
@@ -307,7 +354,11 @@ def _convert_rkv_stats(
                 head_data = rkv_stats[key]
                 # R-KV stores q_abs_mean as query statistic.
                 if "q_abs_mean" in head_data:
-                    q_abs = head_data["q_abs_mean"].to(dtype=dtype)
+                    q_abs = _pad_1d(
+                        head_data["q_abs_mean"].to(dtype=dtype),
+                        freq_count,
+                        fill=1.0,
+                    )
                     all_q_abs_mean.append(q_abs)
                 else:
                     all_q_abs_mean.append(
@@ -316,10 +367,10 @@ def _convert_rkv_stats(
 
                 if "q_mean_real" in head_data and "q_mean_imag" in head_data:
                     all_q_mean_real.append(
-                        head_data["q_mean_real"].to(dtype=dtype)
+                        _pad_1d(head_data["q_mean_real"].to(dtype=dtype), freq_count)
                     )
                     all_q_mean_imag.append(
-                        head_data["q_mean_imag"].to(dtype=dtype)
+                        _pad_1d(head_data["q_mean_imag"].to(dtype=dtype), freq_count)
                     )
 
         # Stack all attention heads: [num_attention_heads, freq_count]
@@ -336,6 +387,7 @@ def _convert_rkv_stats(
         head_stats[layer_idx] = {
             "freq_scale_sq": default_freq_scale_sq.clone(),
             "q_abs_mean": q_abs_mean.to(device),
+            "freq_count": layer_freq_count,
         }
 
         # Add q_mean_complex if available

--- a/triattention/vllm/runtime/runner.py
+++ b/triattention/vllm/runtime/runner.py
@@ -57,6 +57,7 @@ class TriAttentionModelRunner:
             "prefill_exceeds_budget",
             "req_state_not_found",
             "batch_queue_dedup",
+            "no_compactable_groups",
         }
 
     def __getattr__(self, name: str) -> Any:

--- a/triattention/vllm/runtime/selector_hf.py
+++ b/triattention/vllm/runtime/selector_hf.py
@@ -305,6 +305,23 @@ def build_triattention_selector(
         group_size: int,
         round_start: int,
     ) -> torch.Tensor:
+        runtime_freq_count = int(keys_dense.shape[-1]) // 2
+        if runtime_freq_count <= 0:
+            raise RuntimeError("invalid_runtime_head_dim")
+        if int(score_freq_scale_sq.shape[-1]) != runtime_freq_count:
+            score_freq_scale_sq = score_freq_scale_sq[..., :runtime_freq_count].contiguous()
+            sliced_stats: dict[str, torch.Tensor] = {}
+            for key, value in score_head_stats.items():
+                if key in {"q_abs_mean"} and isinstance(value, torch.Tensor):
+                    sliced_stats[key] = value[..., :runtime_freq_count].contiguous()
+                elif key in {"q_mean_complex"} and isinstance(value, torch.Tensor):
+                    sliced_stats[key] = value[..., :runtime_freq_count, :].contiguous()
+                else:
+                    sliced_stats[key] = value
+            score_head_stats = sliced_stats
+        omega = compressor.omega
+        if isinstance(omega, torch.Tensor) and int(omega.shape[-1]) != runtime_freq_count:
+            omega = omega[:runtime_freq_count].contiguous()
         score_inputs = (
             keys_dense.repeat_interleave(group_size, dim=1).contiguous()
             if use_hf_group_max and group_size > 1
@@ -315,7 +332,7 @@ def build_triattention_selector(
                 key_states=score_inputs,
                 cache_positions=None,
                 head_stats=score_head_stats,
-                omega=compressor.omega,
+                omega=omega,
                 offsets=compressor.offsets,
                 freq_scale_sq=score_freq_scale_sq,
                 config=tri_cfg,


### PR DESCRIPTION
Thank you for the solid work on this attention backend.

This pull request implements calibration for the mixed head dimension model series Gemma4, with the work done focused around the 26B-A4B Mixture of Experts at 200k token window length.

Calibration on MacOS (M3 Max 128G) requires universal-metal-flash-attention and chunked 32k token intervals for combination of all stats at the end.

Using CUDA across a single H100 80G we used flash-attention 3 for head_dim=256 and torch SDPA for head_dim=512. Flash Attention3 from the huggingface kernels library was then used to calibrate TriAttention using 200k tokens from the KJV bible, downloaded from Project Gutenburg.

The Gemma4 26B-A4B model, when served with vLLM's chunked prefill and this patch set, gets to ~32gb of VRAM occupancy with a 350k total context window (200k input tokens and 150k output which took more than 30 minutes to generate) which isn't even possible without TriAttention.

**Enhanced support for variable head dimensions and frequency counts:**

* Both `sglang` and `vllm` stats loaders (`stats_loader.py`, `utils.py`) now compute and propagate per-layer `layer_head_dims` and `layer_freq_counts`, falling back to sensible defaults when necessary. This allows correct handling of models with mixed head dimensions across layers. [[1]](diffhunk://#diff-60f1e695a007bc8a413c6fa24a1c9dd40b9a77e74f12323b55f891d50bd776ecL174-R203) [[2]](diffhunk://#diff-7fe6baef1dc1805cabcee360119988d8e18a9ae9cf2bca73db17d3d489dcd8a1L175-R207)
* All relevant statistics (`q_abs_mean`, `q_mean_real`, `q_mean_imag`) are padded or sliced to the maximum per-layer frequency count, ensuring tensors are consistent in shape and preventing runtime errors. [[1]](diffhunk://#diff-60f1e695a007bc8a413c6fa24a1c9dd40b9a77e74f12323b55f891d50bd776ecR272-R287) [[2]](diffhunk://#diff-7fe6baef1dc1805cabcee360119988d8e18a9ae9cf2bca73db17d3d489dcd8a1R333-R361)
* The validation logic in `validate_stats_against_model` now checks for minimum required frequency dimensions per layer, rather than strict equality, accommodating models with larger-than-expected stats. [[1]](diffhunk://#diff-60f1e695a007bc8a413c6fa24a1c9dd40b9a77e74f12323b55f891d50bd776ecL355-R429) [[2]](diffhunk://#diff-60f1e695a007bc8a413c6fa24a1c9dd40b9a77e74f12323b55f891d50bd776ecR471-L400) [[3]](diffhunk://#diff-60f1e695a007bc8a413c6fa24a1c9dd40b9a77e74f12323b55f891d50bd776ecL410-R503) [[4]](diffhunk://#diff-60f1e695a007bc8a413c6fa24a1c9dd40b9a77e74f12323b55f891d50bd776ecL439-R519)

**API and test improvements:**

* The new `layer_freq_counts` property is exposed on the stats bundle for easy access to per-layer frequency counts.
* Added comprehensive tests (`test_gemma4_mixed_head_stats.py`) to verify that both `sglang` and `vllm` loaders correctly handle Gemma-4-like stats with mixed head dimensions, including proper padding and validation.

**Other improvements and fixes:**

* The scoring utility (`scoring_utils.py`) now slices all statistics, frequency scales, and omega vectors to the runtime frequency count, preventing dimension mismatches during scoring. [[1]](diffhunk://#diff-056c54a89c9d14ed2f34b7d70f3f9695b089a72396aa3b0b0e110148a2a30454L130-R141) [[2]](diffhunk://#diff-056c54a89c9d14ed2f34b7d70f3f9695b089a72396aa3b0b0e110148a2a30454L151-R158)
* Added a new error string to the set of recognized error types in the runner for improved error handling.