### PR TITLE
fix: tolerate no_compactable_groups skip in strict compaction mode

### DIFF
--- a/triattention/vllm/runtime/runner.py
+++ b/triattention/vllm/runtime/runner.py
@@ -57,6 +57,7 @@ class TriAttentionModelRunner:
             "prefill_exceeds_budget",
             "req_state_not_found",
             "batch_queue_dedup",
+            "no_compactable_groups",
         }
 
     def __getattr__(self, name: str) -> Any:

--- a/triattention/vllm/runtime/state.py
+++ b/triattention/vllm/runtime/state.py
@@ -132,6 +132,7 @@ class RequestStateStore:
             return
         state.pending_triggers = max(state.pending_triggers - 1, 0)
         state.last_trigger_reason = f"skipped:{reason}"
+        state.last_compression_step = step
 
     def remove(self, req_id: str) -> None:
         self._states.pop(req_id, None)


### PR DESCRIPTION
## Problem

When running vLLM server with TriAttention runtime enabled, the server crashes after ~2000 decode steps with:

```
RuntimeError: TRIATTN_FATAL_TRITON_SCORING_REQUIRED:unexpected_skip:req=...:step=2129:reason=no_compactable_groups
```

## Root Cause

vLLM V1's async scheduling can cause the scheduler's estimated KV cache length to drift from the worker's actual block allocation state. When the scheduler signals compression but the worker finds all KV cache groups have empty block IDs or zero effective tokens, `run_group_compaction_pipeline` returns `no_compactable_groups`. This benign race condition was treated as a fatal error because it wasn't in the allowed skip reasons set.

The issue is in `triattention/vllm/runtime/runner.py` line 53:

```python
self._strict_no_downgrade = bool(self.config.enable_experimental_kv_compaction)
```

When `strict_no_downgrade` is True (default), any skip reason not in `_allowed_strict_skip_reasons` raises a fatal `RuntimeError`.

## Changes

1. **`runner.py`**: Add `"no_compactable_groups"` to `_allowed_strict_skip_reasons` so the condition is treated as a benign skip rather than a fatal error

2. **`state.py`**: Set `last_compression_step` in `mark_compression_skipped()` to enable the existing `batch_queue_dedup` guard, preventing tight retry loops when a skip occurs on consecutive steps

## Verification

The error was observed on a production vLLM 0.21.0 deployment with Qwen3-8B model, `TRIATTN_RUNTIME_KV_BUDGET=2048`, handling 8 concurrent chat requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)