### PR TITLE
fix: harden R-KV stats loader metadata

### DIFF
--- a/triattention/sglang/stats_loader.py
+++ b/triattention/sglang/stats_loader.py
@@ -236,11 +236,17 @@ def load_stats(
                 dtype=dtype,
                 device=device,
             ).to(device=device, dtype=torch.float32)
-            freq_scale_sq = freq_scale.pow(2)  # [freq_count]
+            freq_scale_sq = freq_scale.flatten().pow(2)  # [freq_count]
         except Exception:
             pass
     if freq_scale_sq is None:
         freq_scale_sq = torch.ones(freq_count, device=device, dtype=torch.float32)
+    elif freq_scale_sq.numel() < freq_count:
+        padded = torch.ones(freq_count, device=device, dtype=torch.float32)
+        padded[: freq_scale_sq.numel()] = freq_scale_sq
+        freq_scale_sq = padded
+    else:
+        freq_scale_sq = freq_scale_sq[:freq_count].contiguous()
 
     # --- build per-layer stats at attention-head granularity ---
     # Each layer stores tensors with dim-0 = num_attention_heads

--- a/triattention/tests/test_rkv_loader_metadata.py
+++ b/triattention/tests/test_rkv_loader_metadata.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import torch
+
+from triattention.vllm.core.utils import load_frequency_stats
+
+
+def test_vllm_rkv_loader_uses_num_key_value_heads_metadata(tmp_path: Path) -> None:
+    stats = {}
+    for layer_idx in range(1):
+        for head_idx in range(4):
+            stats[f"layer{layer_idx:02d}_head{head_idx:02d}"] = {
+                "q_mean_real": torch.ones(4),
+                "q_mean_imag": torch.zeros(4),
+                "q_abs_mean": torch.ones(4),
+            }
+    path = tmp_path / "rkv_stats.pt"
+    torch.save(
+        {
+            "metadata": {
+                "head_dim": 8,
+                "num_key_value_heads": 2,
+                "rope_style": "half",
+                "rope_theta": 10000.0,
+            },
+            "stats": stats,
+        },
+        path,
+    )
+
+    metadata, head_stats = load_frequency_stats(
+        path,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+
+    assert metadata["num_attention_heads"] == 4
+    assert metadata["num_kv_heads"] == 2
+    assert metadata["gqa_ratio"] == 2
+    assert head_stats[0]["q_mean_complex"].shape == (2, 4, 2)
+    assert head_stats[0]["q_abs_mean"].shape == (2, 4)

--- a/triattention/vllm/core/utils.py
+++ b/triattention/vllm/core/utils.py
@@ -177,7 +177,11 @@ def _convert_rkv_stats(
 
     # Handle GQA: if num_kv_heads specified and < num_attention_heads
     if num_kv_heads is None:
-        num_kv_heads = num_attention_heads
+        meta_kv_heads = rkv_metadata.get(
+            "num_kv_heads",
+            rkv_metadata.get("num_key_value_heads"),
+        )
+        num_kv_heads = int(meta_kv_heads) if meta_kv_heads else num_attention_heads
 
     gqa_ratio = num_attention_heads // num_kv_heads if num_kv_heads > 0 else 1
 
@@ -281,7 +285,13 @@ def _convert_rkv_stats(
                     dtype=dtype,
                     device=device,
                 ).to(device=device, dtype=dtype)
-                freq_scale_sq = freq_scale.pow(2)
+                freq_scale_sq = freq_scale.flatten().pow(2)
+                if freq_scale_sq.numel() < freq_count:
+                    padded = torch.ones(freq_count, device=device, dtype=dtype)
+                    padded[: freq_scale_sq.numel()] = freq_scale_sq
+                    freq_scale_sq = padded
+                else:
+                    freq_scale_sq = freq_scale_sq[:freq_count].contiguous()
                 return freq_scale_sq.unsqueeze(0).expand(num_kv_heads, -1).contiguous()
             except Exception:
                 pass


### PR DESCRIPTION
## Summary

This splits out the low-risk loader hardening from the Gemma4 mixed-head runtime work.

- Use `metadata.num_kv_heads` / `metadata.num_key_value_heads` when converting R-KV stats if `num_kv_heads` is not passed explicitly.
- Clamp or pad derived `freq_scale_sq` to the expected frequency count in both vLLM and SGLang loaders.
- Add a focused regression test for the `num_key_value_heads` fallback and GQA aggregation shape.

## Tests

- `pytest triattention/tests/test_rkv_loader_metadata.py -q`
- `python -m py_compile triattention/vllm/core/utils.py triattention/sglang/stats_loader.py triattention/tests/test_rkv_loader_metadata.py`
- `git diff --check`

This PR intentionally avoids mixed-head-dimension runtime support; that is split into a follow-up PR with per-layer RoPE frequency bases.