### PR TITLE
fix: score mixed-head layers with native RoPE bases

### DIFF
--- a/triattention/sglang/scoring_utils.py
+++ b/triattention/sglang/scoring_utils.py
@@ -127,11 +127,29 @@ def score_layer_hf_aligned(
         )
 
     # Slice stats to local shard's attention heads.
-    q_mean_complex_local = layer_stats_full["q_mean_complex"][head_start:head_end]
-    q_abs_mean_local = layer_stats_full["q_abs_mean"][head_start:head_end]
+    runtime_freq_count = int(layer_k.shape[-1]) // 2
+    if runtime_freq_count <= 0:
+        raise RuntimeError("invalid_runtime_head_dim")
+    layer_omega = compressor.get_layer_omega(layer_idx)
+    if int(layer_omega.shape[-1]) != runtime_freq_count:
+        raise RuntimeError(
+            f"omega_dim_mismatch:stats={int(layer_omega.shape[-1])},"
+            f"runtime={runtime_freq_count}"
+        )
+    q_mean_complex_local = layer_stats_full["q_mean_complex"][
+        head_start:head_end, :, :
+    ].contiguous()
+    q_abs_mean_local = layer_stats_full["q_abs_mean"][
+        head_start:head_end, :
+    ].contiguous()
 
     # freq_scale_sq is shared across heads -- expand to local head count.
     freq_scale_sq_1d = layer_stats_full["freq_scale_sq"]  # [freq_count]
+    if int(freq_scale_sq_1d.shape[-1]) != runtime_freq_count:
+        raise RuntimeError(
+            f"freq_scale_dim_mismatch:stats={int(freq_scale_sq_1d.shape[-1])},"
+            f"runtime={runtime_freq_count}"
+        )
     freq_scale_sq_expanded = freq_scale_sq_1d.unsqueeze(0).expand(
         num_attention_heads_local, -1
     ).contiguous()
@@ -148,7 +166,7 @@ def score_layer_hf_aligned(
         key_states=layer_k_expanded,
         cache_positions=None,
         head_stats=head_stats_for_scoring,
-        omega=compressor.omega,
+        omega=layer_omega,
         offsets=compressor.offsets,
         freq_scale_sq=freq_scale_sq_expanded,
         config=compressor.config,

--- a/triattention/sglang/stats_loader.py
+++ b/triattention/sglang/stats_loader.py
@@ -236,11 +236,17 @@ def load_stats(
                 dtype=dtype,
                 device=device,
             ).to(device=device, dtype=torch.float32)
-            freq_scale_sq = freq_scale.pow(2)  # [freq_count]
+            freq_scale_sq = freq_scale.flatten().pow(2)  # [freq_count]
         except Exception:
             pass
     if freq_scale_sq is None:
         freq_scale_sq = torch.ones(freq_count, device=device, dtype=torch.float32)
+    elif freq_scale_sq.numel() < freq_count:
+        padded = torch.ones(freq_count, device=device, dtype=torch.float32)
+        padded[: freq_scale_sq.numel()] = freq_scale_sq
+        freq_scale_sq = padded
+    else:
+        freq_scale_sq = freq_scale_sq[:freq_count].contiguous()
 
     # --- build per-layer stats at attention-head granularity ---
     # Each layer stores tensors with dim-0 = num_attention_heads

--- a/triattention/sglang/stats_loader.py
+++ b/triattention/sglang/stats_loader.py
@@ -93,6 +93,11 @@ class StatsBundle:
         return self.head_dim // 2
 
     @property
+    def layer_freq_counts(self) -> list[int]:
+        raw = self.metadata.get("layer_freq_counts", [])
+        return [int(x) for x in raw] if isinstance(raw, (list, tuple)) else []
+
+    @property
     def rope_style(self) -> str:
         return str(self.metadata.get("rope_style", "half"))
 
@@ -171,8 +176,31 @@ def load_stats(
 
     num_layers = len(layer_nums)
     num_attention_heads = len(head_nums)
-    head_dim = rkv_metadata.get("head_dim", 128)
-    freq_count = head_dim // 2
+    layer_head_dims_raw = rkv_metadata.get("layer_head_dims")
+    layer_head_dims = (
+        {int(i): int(v) for i, v in enumerate(layer_head_dims_raw)}
+        if isinstance(layer_head_dims_raw, (list, tuple))
+        else {}
+    )
+
+    def _entry_freq_count(layer_idx: int) -> int:
+        for head_idx in sorted(head_nums):
+            entry = rkv_stats_raw.get(f"layer{layer_idx:02d}_head{head_idx:02d}")
+            if not isinstance(entry, dict):
+                continue
+            for stat_name in ("q_abs_mean", "q_mean_real", "q_mean_imag"):
+                value = entry.get(stat_name)
+                if isinstance(value, torch.Tensor):
+                    return int(value.numel())
+        if layer_idx in layer_head_dims:
+            return max(1, int(layer_head_dims[layer_idx]) // 2)
+        return int(rkv_metadata.get("head_dim", 128)) // 2
+
+    layer_freq_counts = {
+        int(layer_idx): _entry_freq_count(int(layer_idx)) for layer_idx in layer_nums
+    }
+    max_freq_count = max(layer_freq_counts.values()) if layer_freq_counts else 64
+    head_dim = max(int(rkv_metadata.get("head_dim", max_freq_count * 2)), max_freq_count * 2)
 
     # Compute GQA group size (do NOT aggregate)
     effective_num_kv_heads = num_kv_heads if num_kv_heads else num_attention_heads
@@ -183,10 +211,10 @@ def load_stats(
     inv_freq_raw = rkv_metadata.get("inv_freq")
     if isinstance(inv_freq_raw, torch.Tensor):
         omega = inv_freq_raw.to(device=device, dtype=torch.float32)
-        omega = omega[:freq_count].contiguous()
+        omega = omega[:max_freq_count].contiguous()
     elif isinstance(inv_freq_raw, (list, tuple)):
         omega = torch.tensor(inv_freq_raw, device=device, dtype=torch.float32)
-        omega = omega[:freq_count].contiguous()
+        omega = omega[:max_freq_count].contiguous()
     else:
         # Fallback: derive from model config
         model_id = rkv_metadata.get("model_name", rkv_metadata.get("model_path"))
@@ -206,47 +234,58 @@ def load_stats(
                 inv_freq = getattr(rotary, "inv_freq", None)
                 if isinstance(inv_freq, torch.Tensor):
                     omega = inv_freq.to(device=device, dtype=torch.float32)[
-                        :freq_count
+                        :max_freq_count
                     ].contiguous()
             except Exception:
                 pass
 
     # --- derive freq_scale_sq (shared across all heads, like HF) ---
-    freq_scale_sq: Optional[torch.Tensor] = None
     model_id = rkv_metadata.get("model_name", rkv_metadata.get("model_path"))
-    if model_id:
+
+    def _derive_freq_scale_sq(layer_freq_count: int) -> torch.Tensor:
         try:
             from transformers import AutoConfig
             from triattention.common.rope_utils import (
                 build_rotary,
                 compute_frequency_scaling,
             )
-            model_config = AutoConfig.from_pretrained(
-                str(model_id), trust_remote_code=True,
-            )
-            rotary = build_rotary(
-                cache_device=device,
-                model_path=Path(str(model_id)),
-                dtype=dtype,
-                config=model_config,
-            )
-            freq_scale = compute_frequency_scaling(
-                rotary=rotary,
-                head_dim=head_dim,
-                dtype=dtype,
-                device=device,
-            ).to(device=device, dtype=torch.float32)
-            freq_scale_sq = freq_scale.flatten().pow(2)  # [freq_count]
+            if model_id:
+                model_config = AutoConfig.from_pretrained(
+                    str(model_id), trust_remote_code=True,
+                )
+                rotary = build_rotary(
+                    cache_device=device,
+                    model_path=Path(str(model_id)),
+                    dtype=dtype,
+                    config=model_config,
+                )
+                freq_scale = compute_frequency_scaling(
+                    rotary=rotary,
+                    head_dim=layer_freq_count * 2,
+                    dtype=dtype,
+                    device=device,
+                ).to(device=device, dtype=torch.float32)
+                freq_scale_sq = freq_scale.flatten().pow(2)
+                if freq_scale_sq.numel() < layer_freq_count:
+                    padded = torch.ones(layer_freq_count, device=device, dtype=torch.float32)
+                    padded[: freq_scale_sq.numel()] = freq_scale_sq
+                    freq_scale_sq = padded
+                else:
+                    freq_scale_sq = freq_scale_sq[:layer_freq_count].contiguous()
+                return freq_scale_sq
         except Exception:
             pass
-    if freq_scale_sq is None:
-        freq_scale_sq = torch.ones(freq_count, device=device, dtype=torch.float32)
-    elif freq_scale_sq.numel() < freq_count:
-        padded = torch.ones(freq_count, device=device, dtype=torch.float32)
-        padded[: freq_scale_sq.numel()] = freq_scale_sq
-        freq_scale_sq = padded
-    else:
-        freq_scale_sq = freq_scale_sq[:freq_count].contiguous()
+        return torch.ones(layer_freq_count, device=device, dtype=torch.float32)
+
+    def _fit_1d(value: torch.Tensor, target: int, *, fill: float = 0.0) -> torch.Tensor:
+        value = value.flatten()
+        if value.numel() == target:
+            return value
+        if value.numel() > target:
+            return value[:target]
+        out = torch.full((target,), fill, device=value.device, dtype=value.dtype)
+        out[: value.numel()] = value
+        return out
 
     # --- build per-layer stats at attention-head granularity ---
     # Each layer stores tensors with dim-0 = num_attention_heads
@@ -257,6 +296,7 @@ def load_stats(
         all_q_mean_real = []
         all_q_mean_imag = []
         all_q_abs_mean = []
+        layer_freq_count = int(layer_freq_counts.get(layer_idx, max_freq_count))
 
         for head_idx in sorted(head_nums):
             key = f"layer{layer_idx:02d}_head{head_idx:02d}"
@@ -264,27 +304,39 @@ def load_stats(
                 head_data = rkv_stats_raw[key]
                 if "q_abs_mean" in head_data:
                     all_q_abs_mean.append(
-                        head_data["q_abs_mean"].to(device=device, dtype=torch.float32)
+                        _fit_1d(
+                            head_data["q_abs_mean"].to(device=device, dtype=torch.float32),
+                            layer_freq_count,
+                            fill=1.0,
+                        )
                     )
                 else:
                     all_q_abs_mean.append(
-                        torch.ones(freq_count, device=device, dtype=torch.float32)
+                        torch.ones(layer_freq_count, device=device, dtype=torch.float32)
                     )
                 if "q_mean_real" in head_data and "q_mean_imag" in head_data:
                     all_q_mean_real.append(
-                        head_data["q_mean_real"].to(device=device, dtype=torch.float32)
+                        _fit_1d(
+                            head_data["q_mean_real"].to(device=device, dtype=torch.float32),
+                            layer_freq_count,
+                        )
                     )
                     all_q_mean_imag.append(
-                        head_data["q_mean_imag"].to(device=device, dtype=torch.float32)
+                        _fit_1d(
+                            head_data["q_mean_imag"].to(device=device, dtype=torch.float32),
+                            layer_freq_count,
+                        )
                     )
 
         # Stack all attention heads WITHOUT GQA aggregation.
         # Shape: [num_attention_heads, freq_count]
         q_abs_mean_stacked = torch.stack(all_q_abs_mean, dim=0)
 
-        layer_entry: Dict[str, torch.Tensor] = {
+        freq_scale_sq = _derive_freq_scale_sq(layer_freq_count)
+        layer_entry: Dict[str, Any] = {
             "freq_scale_sq": freq_scale_sq.clone(),  # [freq_count] (shared)
             "q_abs_mean": q_abs_mean_stacked,  # [num_attention_heads, freq_count]
+            "freq_count": layer_freq_count,
         }
 
         if all_q_mean_real and all_q_mean_imag:
@@ -303,6 +355,14 @@ def load_stats(
         "num_kv_heads": effective_num_kv_heads,
         "head_dim": head_dim,
         "num_layers": num_layers,
+        "layer_head_dims": [
+            int(layer_head_dims.get(layer_idx, layer_freq_counts.get(layer_idx, max_freq_count) * 2))
+            for layer_idx in range(num_layers)
+        ],
+        "layer_freq_counts": [
+            int(layer_freq_counts.get(layer_idx, max_freq_count))
+            for layer_idx in range(num_layers)
+        ],
         "rope_style": rkv_metadata.get("rope_style", "half"),
         "rope_type": rkv_metadata.get("rope_type"),
         "rope_theta": rkv_metadata.get("rope_theta", 10000.0),
@@ -358,7 +418,17 @@ def validate_stats_against_model(
     """
     errors = []
 
-    if bundle.head_dim != model_head_dim:
+    layer_head_dims_raw = bundle.metadata.get("layer_head_dims", [])
+    layer_head_dims = (
+        [int(x) for x in layer_head_dims_raw]
+        if isinstance(layer_head_dims_raw, (list, tuple))
+        else []
+    )
+    model_head_dims = {int(model_head_dim)}
+    if layer_head_dims:
+        model_head_dims.add(max(layer_head_dims))
+
+    if bundle.head_dim not in model_head_dims:
         errors.append(
             f"head_dim mismatch: stats={bundle.head_dim}, "
             f"model={model_head_dim}"
@@ -400,10 +470,14 @@ def validate_stats_against_model(
     # Accept if tensor dim-0 == model_num_kv_heads (aggregated) or is
     # a multiple of model_num_kv_heads (attention-head granularity).
     for layer_idx, layer_data in bundle.head_stats.items():
+        expected_freq = (
+            int(layer_head_dims[layer_idx]) // 2
+            if layer_idx < len(layer_head_dims)
+            else int(model_head_dim) // 2
+        )
         q_mean = layer_data.get("q_mean_complex")
         if q_mean is not None:
             actual_heads = q_mean.shape[0]
-            expected_freq = model_head_dim // 2
             if actual_heads != model_num_kv_heads and (
                 actual_heads == 0 or model_num_kv_heads == 0
                 or actual_heads % model_num_kv_heads != 0
@@ -424,7 +498,6 @@ def validate_stats_against_model(
         if freq_sq is not None:
             # freq_scale_sq can be 1D [freq_count] (shared)
             # or 2D [num_heads, freq_count].
-            expected_freq = model_head_dim // 2
             if freq_sq.dim() == 1:
                 if freq_sq.shape[0] != expected_freq:
                     errors.append(
@@ -447,8 +520,6 @@ def validate_stats_against_model(
                         f"layer {layer_idx} freq_scale_sq freq dim "
                         f"{freq_sq.shape[-1]} != expected {expected_freq}"
                     )
-        # Only check the first layer with stats to avoid verbose output.
-        break
 
     if errors:
         raise ValueError(

--- a/triattention/tests/test_gemma4_mixed_head_stats.py
+++ b/triattention/tests/test_gemma4_mixed_head_stats.py
@@ -1,0 +1,169 @@
+from pathlib import Path
+
+import pytest
+import torch
+
+from triattention.sglang.stats_loader import (
+    load_stats,
+    validate_stats_against_model,
+)
+from triattention.vllm.core.compressor import TriAttentionCompressor
+from triattention.vllm.core.config import TriAttentionConfig
+from triattention.vllm.core.scoring import compute_scores_pytorch
+from triattention.vllm.core.utils import compute_rope_frequencies, load_frequency_stats
+
+
+def _gemma4_like_payload() -> dict:
+    stats = {}
+    for layer_idx, freq_count in [(0, 128), (1, 256)]:
+        for head_idx in range(4):
+            value = float(layer_idx + head_idx + 1)
+            stats[f"layer{layer_idx:02d}_head{head_idx:02d}"] = {
+                "q_mean_real": torch.full((freq_count,), value),
+                "q_mean_imag": torch.full((freq_count,), value + 0.5),
+                "q_abs_mean": torch.full((freq_count,), value + 1.0),
+            }
+    return {
+        "metadata": {
+            "head_dim": 512,
+            "layer_head_dims": [256, 512],
+            "num_key_value_heads": 2,
+            "rope_style": "half",
+            "rope_theta": 10000.0,
+        },
+        "stats": stats,
+    }
+
+
+def test_vllm_rkv_loader_handles_gemma4_mixed_head_dims(tmp_path: Path) -> None:
+    path = tmp_path / "gemma4_stats.pt"
+    torch.save(_gemma4_like_payload(), path)
+
+    metadata, head_stats = load_frequency_stats(
+        path,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+
+    assert metadata["head_dim"] == 512
+    assert metadata["num_kv_heads"] == 2
+    assert metadata["layer_head_dims"] == [256, 512]
+    assert metadata["layer_freq_counts"] == [128, 256]
+
+    assert head_stats[0]["q_mean_complex"].shape == (2, 128, 2)
+    assert head_stats[1]["q_mean_complex"].shape == (2, 256, 2)
+    assert head_stats[0]["q_abs_mean"].shape == (2, 128)
+    assert head_stats[1]["q_abs_mean"].shape == (2, 256)
+
+
+def test_sglang_rkv_loader_handles_gemma4_mixed_head_dims(tmp_path: Path) -> None:
+    path = tmp_path / "gemma4_stats.pt"
+    torch.save(_gemma4_like_payload(), path)
+
+    bundle = load_stats(
+        str(path),
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+        num_kv_heads=2,
+    )
+
+    assert bundle.head_dim == 512
+    assert bundle.num_kv_heads == 2
+    assert bundle.num_attention_heads == 4
+    assert bundle.gqa_group_size == 2
+    assert bundle.layer_freq_counts == [128, 256]
+
+    assert bundle.head_stats[0]["q_mean_complex"].shape == (4, 128, 2)
+    assert bundle.head_stats[1]["q_mean_complex"].shape == (4, 256, 2)
+    assert bundle.head_stats[0]["q_abs_mean"].shape == (4, 128)
+    assert bundle.head_stats[1]["q_abs_mean"].shape == (4, 256)
+
+    validate_stats_against_model(
+        bundle,
+        model_num_layers=2,
+        model_num_kv_heads=2,
+        model_head_dim=256,
+    )
+    validate_stats_against_model(
+        bundle,
+        model_num_layers=2,
+        model_num_kv_heads=2,
+        model_head_dim=512,
+    )
+
+
+def test_vllm_mixed_head_scoring_uses_native_layer_frequency_basis(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "gemma4_stats.pt"
+    torch.save(_gemma4_like_payload(), path)
+
+    config = TriAttentionConfig(
+        stats_path=path,
+        device=torch.device("cpu"),
+        compute_dtype=torch.float32,
+        topk_dtype=torch.float32,
+        use_triton_scoring=False,
+        use_trig_cache=False,
+        disable_mlr=True,
+        kv_budget=2,
+        window_size=0,
+        offset_max_length=2,
+    )
+    compressor = TriAttentionCompressor(config)
+    compressor._lazy_init()
+
+    native_256 = compute_rope_frequencies(256, 10000.0, device=torch.device("cpu"))
+    sliced_512 = compute_rope_frequencies(512, 10000.0, device=torch.device("cpu"))[
+        :128
+    ]
+    assert torch.allclose(compressor.get_layer_omega(0), native_256)
+    assert not torch.allclose(native_256[64:], sliced_512[64:])
+
+    torch.manual_seed(0)
+    key_states = torch.randn(1, 2, 5, 256)
+    scores = compressor._compute_scores(key_states=key_states, layer_idx=0)
+    reference = compute_scores_pytorch(
+        key_states=key_states,
+        cache_positions=None,
+        head_stats=compressor.head_stats[0],
+        omega=native_256,
+        offsets=compressor.offsets,
+        freq_scale_sq=compressor.get_layer_freq_scale_sq(0),
+        config=compressor.config,
+        round_start=compressor.state.get_round_start(),
+    )
+    wrong_sliced_basis = compute_scores_pytorch(
+        key_states=key_states,
+        cache_positions=None,
+        head_stats=compressor.head_stats[0],
+        omega=sliced_512,
+        offsets=compressor.offsets,
+        freq_scale_sq=compressor.get_layer_freq_scale_sq(0),
+        config=compressor.config,
+        round_start=compressor.state.get_round_start(),
+    )
+
+    assert torch.allclose(scores, reference)
+    assert not torch.allclose(scores, wrong_sliced_basis)
+
+
+def test_sglang_validation_checks_all_mixed_head_layers(tmp_path: Path) -> None:
+    path = tmp_path / "gemma4_stats.pt"
+    torch.save(_gemma4_like_payload(), path)
+
+    bundle = load_stats(
+        str(path),
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+        num_kv_heads=2,
+    )
+    bundle.head_stats[1]["freq_scale_sq"] = torch.ones(128)
+
+    with pytest.raises(ValueError, match="layer 1 freq_scale_sq"):
+        validate_stats_against_model(
+            bundle,
+            model_num_layers=2,
+            model_num_kv_heads=2,
+            model_head_dim=512,
+        )

--- a/triattention/tests/test_rkv_loader_metadata.py
+++ b/triattention/tests/test_rkv_loader_metadata.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import torch
+
+from triattention.vllm.core.utils import load_frequency_stats
+
+
+def test_vllm_rkv_loader_uses_num_key_value_heads_metadata(tmp_path: Path) -> None:
+    stats = {}
+    for layer_idx in range(1):
+        for head_idx in range(4):
+            stats[f"layer{layer_idx:02d}_head{head_idx:02d}"] = {
+                "q_mean_real": torch.ones(4),
+                "q_mean_imag": torch.zeros(4),
+                "q_abs_mean": torch.ones(4),
+            }
+    path = tmp_path / "rkv_stats.pt"
+    torch.save(
+        {
+            "metadata": {
+                "head_dim": 8,
+                "num_key_value_heads": 2,
+                "rope_style": "half",
+                "rope_theta": 10000.0,
+            },
+            "stats": stats,
+        },
+        path,
+    )
+
+    metadata, head_stats = load_frequency_stats(
+        path,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+
+    assert metadata["num_attention_heads"] == 4
+    assert metadata["num_kv_heads"] == 2
+    assert metadata["gqa_ratio"] == 2
+    assert head_stats[0]["q_mean_complex"].shape == (2, 4, 2)
+    assert head_stats[0]["q_abs_mean"].shape == (2, 4)

--- a/triattention/vllm/core/compressor.py
+++ b/triattention/vllm/core/compressor.py
@@ -54,9 +54,11 @@ class TriAttentionCompressor:
         # RoPE frequencies
         self.inv_freq: Optional[torch.Tensor] = None
         self.omega: Optional[torch.Tensor] = None
+        self.layer_inv_freq: Dict[int, torch.Tensor] = {}
+        self.layer_omega: Dict[int, torch.Tensor] = {}
 
         # Frequency scaling factors
-        self.freq_scale_sq: Optional[torch.Tensor] = None
+        self.freq_scale_sq: Optional[Dict[int, torch.Tensor]] = None
 
         # Precomputed offsets for scoring
         self.offsets: Optional[torch.Tensor] = None
@@ -124,11 +126,14 @@ class TriAttentionCompressor:
         2) derive inv_freq from the real model config when model_path is available;
         3) fallback to metadata/legacy rope_theta-based construction.
         """
+        layer_freq_counts = self._layer_freq_counts()
+        layer_head_dims = self._layer_head_dims()
+        heterogeneous_layers = len(set(layer_head_dims.values())) > 1
         inv_freq_raw = self.metadata.get("inv_freq")
         if isinstance(inv_freq_raw, torch.Tensor):
             inv_freq = inv_freq_raw.to(device=self.config.device, dtype=torch.float32)
             expected_freq_count = int(self.config.head_dim) // 2
-            if inv_freq.numel() < expected_freq_count:
+            if inv_freq.numel() < expected_freq_count and not heterogeneous_layers:
                 raise ValueError(
                     "metadata.inv_freq has fewer elements than required by "
                     f"head_dim={self.config.head_dim}: got {inv_freq.numel()}, "
@@ -142,7 +147,7 @@ class TriAttentionCompressor:
                 dtype=torch.float32,
             )
             expected_freq_count = int(self.config.head_dim) // 2
-            if inv_freq.numel() < expected_freq_count:
+            if inv_freq.numel() < expected_freq_count and not heterogeneous_layers:
                 raise ValueError(
                     "metadata.inv_freq has fewer elements than required by "
                     f"head_dim={self.config.head_dim}: got {inv_freq.numel()}, "
@@ -192,6 +197,33 @@ class TriAttentionCompressor:
         # Match HF/R-KV reference scoring semantics: use rotary inv_freq directly.
         # The scoring formula expects the same frequency basis as the model's RoPE.
         self.omega = self.inv_freq
+        self.layer_inv_freq = {}
+        self.layer_omega = {}
+        layer_inv_freqs_raw = self.metadata.get("layer_inv_freqs")
+        rope_theta = self.metadata.get("rope_theta", 10000.0)
+        for layer_idx, layer_freq_count in layer_freq_counts.items():
+            layer_inv_freq = None
+            if isinstance(layer_inv_freqs_raw, (list, tuple)) and layer_idx < len(layer_inv_freqs_raw):
+                raw = layer_inv_freqs_raw[layer_idx]
+                if isinstance(raw, torch.Tensor):
+                    layer_inv_freq = raw.to(device=self.config.device, dtype=torch.float32)
+                elif isinstance(raw, (list, tuple)):
+                    layer_inv_freq = torch.tensor(raw, device=self.config.device, dtype=torch.float32)
+            if layer_inv_freq is None and not heterogeneous_layers and isinstance(self.inv_freq, torch.Tensor):
+                layer_inv_freq = self.inv_freq
+            if layer_inv_freq is None:
+                layer_inv_freq = compute_rope_frequencies(
+                    layer_head_dims.get(layer_idx, layer_freq_count * 2),
+                    rope_theta=rope_theta,
+                    device=self.config.device,
+                )
+            if layer_inv_freq.numel() < layer_freq_count:
+                raise ValueError(
+                    f"Layer {layer_idx} inv_freq has {layer_inv_freq.numel()} values, "
+                    f"expected at least {layer_freq_count}"
+                )
+            self.layer_inv_freq[layer_idx] = layer_inv_freq[:layer_freq_count].contiguous()
+            self.layer_omega[layer_idx] = self.layer_inv_freq[layer_idx]
 
     def _precompute_freq_scale(self):
         """Precompute frequency scaling factors from stats.
@@ -201,23 +233,76 @@ class TriAttentionCompressor:
         """
         num_layers = self.config.num_layers
         num_kv_heads = self.config.num_kv_heads
-        freq_count = self.config.head_dim // 2
-
-        # Allocate freq_scale_sq tensor
-        self.freq_scale_sq = torch.zeros(
-            num_layers,
-            num_kv_heads,
-            freq_count,
-            device=self.config.device,
-            dtype=self.config.compute_dtype,
-        )
+        self.freq_scale_sq = {}
 
         # Fill from head_stats
         for layer_idx in range(num_layers):
             if layer_idx in self.head_stats:
                 layer_data = self.head_stats[layer_idx]
                 if "freq_scale_sq" in layer_data:
-                    self.freq_scale_sq[layer_idx] = layer_data["freq_scale_sq"]
+                    freq_scale_sq = layer_data["freq_scale_sq"].to(
+                        device=self.config.device,
+                        dtype=self.config.compute_dtype,
+                    )
+                    if freq_scale_sq.dim() == 1:
+                        freq_scale_sq = freq_scale_sq.unsqueeze(0).expand(
+                            num_kv_heads, -1
+                        ).contiguous()
+                    self.freq_scale_sq[layer_idx] = freq_scale_sq
+
+    def _layer_freq_counts(self) -> Dict[int, int]:
+        raw = self.metadata.get("layer_freq_counts") if self.metadata else None
+        if isinstance(raw, (list, tuple)):
+            return {idx: int(value) for idx, value in enumerate(raw)}
+        counts: Dict[int, int] = {}
+        if self.head_stats:
+            for layer_idx, layer_data in self.head_stats.items():
+                q_mean = layer_data.get("q_mean_complex")
+                q_abs = layer_data.get("q_abs_mean")
+                freq_sq = layer_data.get("freq_scale_sq")
+                if isinstance(q_mean, torch.Tensor):
+                    counts[int(layer_idx)] = int(q_mean.shape[-2])
+                elif isinstance(q_abs, torch.Tensor):
+                    counts[int(layer_idx)] = int(q_abs.shape[-1])
+                elif isinstance(freq_sq, torch.Tensor):
+                    counts[int(layer_idx)] = int(freq_sq.shape[-1])
+        if counts:
+            return counts
+        return {
+            idx: int(self.config.head_dim) // 2
+            for idx in range(int(self.config.num_layers))
+        }
+
+    def _layer_head_dims(self) -> Dict[int, int]:
+        raw = self.metadata.get("layer_head_dims") if self.metadata else None
+        if isinstance(raw, (list, tuple)):
+            return {idx: int(value) for idx, value in enumerate(raw)}
+        return {
+            layer_idx: freq_count * 2
+            for layer_idx, freq_count in self._layer_freq_counts().items()
+        }
+
+    def get_layer_omega(self, layer_idx: int) -> torch.Tensor:
+        self._lazy_init()
+        resolved = int(layer_idx)
+        if resolved not in self.layer_omega:
+            keys = sorted(self.layer_omega)
+            if not keys:
+                raise RuntimeError("layer_omega_not_initialized")
+            resolved = keys[resolved % len(keys)]
+        return self.layer_omega[resolved]
+
+    def get_layer_freq_scale_sq(self, layer_idx: int) -> torch.Tensor:
+        self._lazy_init()
+        if self.freq_scale_sq is None:
+            raise RuntimeError("freq_scale_sq_not_initialized")
+        resolved = int(layer_idx)
+        if resolved not in self.freq_scale_sq:
+            keys = sorted(self.freq_scale_sq)
+            if not keys:
+                raise RuntimeError("freq_scale_sq_empty")
+            resolved = keys[resolved % len(keys)]
+        return self.freq_scale_sq[resolved]
 
     def _init_offsets(self):
         """Initialize scoring offsets.
@@ -252,6 +337,8 @@ class TriAttentionCompressor:
             return
 
         if self.offsets is None or self.omega is None:
+            return
+        if len({int(omega.numel()) for omega in self.layer_omega.values()}) > 1:
             return
 
         max_seq_len = self.config.trig_cache_max_seq_len
@@ -375,9 +462,9 @@ class TriAttentionCompressor:
             key_states=key_states,
             cache_positions=None,  # Not used in scoring
             head_stats=layer_stats,
-            omega=self.omega,
+            omega=self.get_layer_omega(layer_idx),
             offsets=self.offsets,
-            freq_scale_sq=self.freq_scale_sq[layer_idx],
+            freq_scale_sq=self.get_layer_freq_scale_sq(layer_idx),
             config=self.config,
             round_start=round_start,
             trig_cache=self.trig_cache,

--- a/triattention/vllm/core/utils.py
+++ b/triattention/vllm/core/utils.py
@@ -172,8 +172,31 @@ def _convert_rkv_stats(
 
     num_layers = len(layer_nums)
     num_attention_heads = len(head_nums)
-    head_dim = rkv_metadata.get("head_dim", 128)
-    freq_count = head_dim // 2
+    layer_head_dims_raw = rkv_metadata.get("layer_head_dims")
+    layer_head_dims = (
+        {int(i): int(v) for i, v in enumerate(layer_head_dims_raw)}
+        if isinstance(layer_head_dims_raw, (list, tuple))
+        else {}
+    )
+
+    def _entry_freq_count(layer_idx: int) -> int:
+        for head_idx in sorted(head_nums):
+            entry = rkv_stats.get(f"layer{layer_idx:02d}_head{head_idx:02d}")
+            if not isinstance(entry, dict):
+                continue
+            for stat_name in ("q_abs_mean", "q_mean_real", "q_mean_imag"):
+                value = entry.get(stat_name)
+                if isinstance(value, torch.Tensor):
+                    return int(value.numel())
+        if layer_idx in layer_head_dims:
+            return max(1, layer_head_dims[layer_idx] // 2)
+        return int(rkv_metadata.get("head_dim", 128)) // 2
+
+    layer_freq_counts = {
+        int(layer_idx): _entry_freq_count(int(layer_idx)) for layer_idx in layer_nums
+    }
+    max_freq_count = max(layer_freq_counts.values()) if layer_freq_counts else 64
+    head_dim = max(int(rkv_metadata.get("head_dim", max_freq_count * 2)), max_freq_count * 2)
 
     # Handle GQA: if num_kv_heads specified and < num_attention_heads
     if num_kv_heads is None:
@@ -194,14 +217,14 @@ def _convert_rkv_stats(
         inv_freq_raw = rkv_metadata.get("inv_freq")
         if isinstance(inv_freq_raw, torch.Tensor):
             inv_freq = inv_freq_raw.to(device=device, dtype=torch.float32)
-            return inv_freq[:freq_count].contiguous()
+            return inv_freq[:max_freq_count].contiguous()
         if isinstance(inv_freq_raw, (list, tuple)):
             inv_freq = torch.tensor(
                 inv_freq_raw,
                 device=device,
                 dtype=torch.float32,
             )
-            return inv_freq[:freq_count].contiguous()
+            return inv_freq[:max_freq_count].contiguous()
 
         model_id = rkv_metadata.get("model_name", rkv_metadata.get("model_path"))
         if model_id:
@@ -223,7 +246,7 @@ def _convert_rkv_stats(
                 inv_freq = getattr(rotary, "inv_freq", None)
                 if isinstance(inv_freq, torch.Tensor):
                     return inv_freq.to(device=device, dtype=torch.float32)[
-                        :freq_count
+                        :max_freq_count
                     ].contiguous()
             except Exception:
                 pass
@@ -237,6 +260,14 @@ def _convert_rkv_stats(
         "num_kv_heads": num_kv_heads,
         "head_dim": head_dim,
         "num_layers": num_layers,
+        "layer_head_dims": [
+            int(layer_head_dims.get(layer_idx, layer_freq_counts.get(layer_idx, max_freq_count) * 2))
+            for layer_idx in range(num_layers)
+        ],
+        "layer_freq_counts": [
+            int(layer_freq_counts.get(layer_idx, max_freq_count))
+            for layer_idx in range(num_layers)
+        ],
         "rope_style": rkv_metadata.get("rope_style", "half"),
         "rope_type": rkv_metadata.get("rope_type"),
         "rope_theta": rkv_metadata.get("rope_theta", 10000.0),
@@ -254,7 +285,7 @@ def _convert_rkv_stats(
     # }
     head_stats = {}
 
-    def _derive_freq_scale_sq_fallback() -> torch.Tensor:
+    def _derive_freq_scale_sq_fallback(layer_freq_count: int) -> torch.Tensor:
         """Derive RoPE frequency scaling from model config when possible.
 
         For R-KV stats format, `q_abs_mean` is a query statistic and should not
@@ -281,17 +312,17 @@ def _convert_rkv_stats(
                 )
                 freq_scale = compute_frequency_scaling(
                     rotary=rotary,
-                    head_dim=head_dim,
+                    head_dim=layer_freq_count * 2,
                     dtype=dtype,
                     device=device,
                 ).to(device=device, dtype=dtype)
                 freq_scale_sq = freq_scale.flatten().pow(2)
-                if freq_scale_sq.numel() < freq_count:
-                    padded = torch.ones(freq_count, device=device, dtype=dtype)
+                if freq_scale_sq.numel() < layer_freq_count:
+                    padded = torch.ones(layer_freq_count, device=device, dtype=dtype)
                     padded[: freq_scale_sq.numel()] = freq_scale_sq
                     freq_scale_sq = padded
                 else:
-                    freq_scale_sq = freq_scale_sq[:freq_count].contiguous()
+                    freq_scale_sq = freq_scale_sq[:layer_freq_count].contiguous()
                 return freq_scale_sq.unsqueeze(0).expand(num_kv_heads, -1).contiguous()
             except Exception:
                 pass
@@ -299,17 +330,27 @@ def _convert_rkv_stats(
         # Explicit fallback when model-derived scaling is unavailable.
         return torch.ones(
             num_kv_heads,
-            freq_count,
+            layer_freq_count,
             device=device,
             dtype=dtype,
         )
 
-    default_freq_scale_sq = _derive_freq_scale_sq_fallback()
+    def _fit_1d(value: torch.Tensor, target: int, *, fill: float = 0.0) -> torch.Tensor:
+        value = value.flatten()
+        if value.numel() == target:
+            return value
+        if value.numel() > target:
+            return value[:target]
+        out = torch.full((target,), fill, dtype=value.dtype)
+        out[: value.numel()] = value
+        return out
+
     for layer_idx in sorted(layer_nums):
         # Collect all attention heads' data for this layer
         all_q_mean_real = []
         all_q_mean_imag = []
         all_q_abs_mean = []
+        layer_freq_count = int(layer_freq_counts.get(layer_idx, max_freq_count))
 
         for head_idx in sorted(head_nums):
             key = f"layer{layer_idx:02d}_head{head_idx:02d}"
@@ -317,19 +358,23 @@ def _convert_rkv_stats(
                 head_data = rkv_stats[key]
                 # R-KV stores q_abs_mean as query statistic.
                 if "q_abs_mean" in head_data:
-                    q_abs = head_data["q_abs_mean"].to(dtype=dtype)
+                    q_abs = _fit_1d(
+                        head_data["q_abs_mean"].to(dtype=dtype),
+                        layer_freq_count,
+                        fill=1.0,
+                    )
                     all_q_abs_mean.append(q_abs)
                 else:
                     all_q_abs_mean.append(
-                        torch.ones(freq_count, dtype=dtype)
+                        torch.ones(layer_freq_count, dtype=dtype)
                     )
 
                 if "q_mean_real" in head_data and "q_mean_imag" in head_data:
                     all_q_mean_real.append(
-                        head_data["q_mean_real"].to(dtype=dtype)
+                        _fit_1d(head_data["q_mean_real"].to(dtype=dtype), layer_freq_count)
                     )
                     all_q_mean_imag.append(
-                        head_data["q_mean_imag"].to(dtype=dtype)
+                        _fit_1d(head_data["q_mean_imag"].to(dtype=dtype), layer_freq_count)
                     )
 
         # Stack all attention heads: [num_attention_heads, freq_count]
@@ -338,14 +383,16 @@ def _convert_rkv_stats(
         # Apply GQA mapping: average Q heads that share each KV head
         if gqa_ratio > 1:
             q_abs_mean = all_q_abs_mean.reshape(
-                num_kv_heads, gqa_ratio, freq_count
+                num_kv_heads, gqa_ratio, layer_freq_count
             ).mean(dim=1)
         else:
             q_abs_mean = all_q_abs_mean
 
+        default_freq_scale_sq = _derive_freq_scale_sq_fallback(layer_freq_count)
         head_stats[layer_idx] = {
             "freq_scale_sq": default_freq_scale_sq.clone(),
             "q_abs_mean": q_abs_mean.to(device),
+            "freq_count": layer_freq_count,
         }
 
         # Add q_mean_complex if available
@@ -356,10 +403,10 @@ def _convert_rkv_stats(
             # Apply GQA mapping
             if gqa_ratio > 1:
                 q_mean_real = all_q_mean_real.reshape(
-                    num_kv_heads, gqa_ratio, freq_count
+                    num_kv_heads, gqa_ratio, layer_freq_count
                 ).mean(dim=1)
                 q_mean_imag = all_q_mean_imag.reshape(
-                    num_kv_heads, gqa_ratio, freq_count
+                    num_kv_heads, gqa_ratio, layer_freq_count
                 ).mean(dim=1)
             else:
                 q_mean_real = all_q_mean_real

--- a/triattention/vllm/core/utils.py
+++ b/triattention/vllm/core/utils.py
@@ -177,7 +177,11 @@ def _convert_rkv_stats(
 
     # Handle GQA: if num_kv_heads specified and < num_attention_heads
     if num_kv_heads is None:
-        num_kv_heads = num_attention_heads
+        meta_kv_heads = rkv_metadata.get(
+            "num_kv_heads",
+            rkv_metadata.get("num_key_value_heads"),
+        )
+        num_kv_heads = int(meta_kv_heads) if meta_kv_heads else num_attention_heads
 
     gqa_ratio = num_attention_heads // num_kv_heads if num_kv_heads > 0 else 1
 
@@ -281,7 +285,13 @@ def _convert_rkv_stats(
                     dtype=dtype,
                     device=device,
                 ).to(device=device, dtype=dtype)
-                freq_scale_sq = freq_scale.pow(2)
+                freq_scale_sq = freq_scale.flatten().pow(2)
+                if freq_scale_sq.numel() < freq_count:
+                    padded = torch.ones(freq_count, device=device, dtype=dtype)
+                    padded[: freq_scale_sq.numel()] = freq_scale_sq
+                    freq_scale_sq = padded
+                else:
+                    freq_scale_sq = freq_scale_sq[:freq_count].contiguous()
                 return freq_scale_sq.unsqueeze(0).expand(num_kv_heads, -1).contiguous()
             except Exception:
                 pass

--- a/triattention/vllm/runtime/selector_hf.py
+++ b/triattention/vllm/runtime/selector_hf.py
@@ -155,7 +155,7 @@ def build_triattention_selector(
             return cached
 
         layer_stats = compressor.head_stats[resolved_layer_idx]
-        layer_freq_scale_sq = compressor.freq_scale_sq[resolved_layer_idx]
+        layer_freq_scale_sq = compressor.get_layer_freq_scale_sq(resolved_layer_idx)
         source_heads = int(layer_freq_scale_sq.shape[0])
         if source_heads == target_heads:
             reduced = (layer_stats, layer_freq_scale_sq)
@@ -214,6 +214,7 @@ def build_triattention_selector(
         (
             score_head_stats,
             score_freq_scale_sq,
+            score_omega,
             use_hf_group_max,
             group_size,
         ) = _resolve_layer_score_inputs(
@@ -225,6 +226,7 @@ def build_triattention_selector(
             keys_dense=keys_dense,
             score_head_stats=score_head_stats,
             score_freq_scale_sq=score_freq_scale_sq,
+            score_omega=score_omega,
             use_hf_group_max=use_hf_group_max,
             group_size=group_size,
             round_start=round_start,
@@ -243,10 +245,11 @@ def build_triattention_selector(
         *,
         layer_idx: int,
         runtime_heads: int,
-    ) -> tuple[dict[str, torch.Tensor], torch.Tensor, bool, int]:
+    ) -> tuple[dict[str, torch.Tensor], torch.Tensor, torch.Tensor, bool, int]:
         resolved_layer_idx = _resolve_layer_idx_for_stats(layer_idx)
         layer_head_stats = compressor.head_stats[resolved_layer_idx]
-        layer_freq_scale_sq = compressor.freq_scale_sq[resolved_layer_idx]
+        layer_freq_scale_sq = compressor.get_layer_freq_scale_sq(resolved_layer_idx)
+        layer_omega = compressor.get_layer_omega(resolved_layer_idx)
         stats_heads = int(layer_freq_scale_sq.shape[0])
         use_hf_group_max = (
             stats_heads != runtime_heads
@@ -272,7 +275,7 @@ def build_triattention_selector(
                 resolved_layer_idx=resolved_layer_idx,
                 target_heads=runtime_heads,
             )
-        return score_head_stats, score_freq_scale_sq, use_hf_group_max, group_size
+        return score_head_stats, score_freq_scale_sq, layer_omega, use_hf_group_max, group_size
 
     def _reduce_grouped_head_scores(
         *,
@@ -301,10 +304,24 @@ def build_triattention_selector(
         keys_dense: torch.Tensor,
         score_head_stats: dict[str, torch.Tensor],
         score_freq_scale_sq: torch.Tensor,
+        score_omega: torch.Tensor,
         use_hf_group_max: bool,
         group_size: int,
         round_start: int,
     ) -> torch.Tensor:
+        runtime_freq_count = int(keys_dense.shape[-1]) // 2
+        if runtime_freq_count <= 0:
+            raise RuntimeError("invalid_runtime_head_dim")
+        if int(score_freq_scale_sq.shape[-1]) != runtime_freq_count:
+            raise RuntimeError(
+                f"{TRITON_SCORING_REQUIRED_MARKER}:freq_scale_dim_mismatch:"
+                f"stats={int(score_freq_scale_sq.shape[-1])},runtime={runtime_freq_count}"
+            )
+        if int(score_omega.shape[-1]) != runtime_freq_count:
+            raise RuntimeError(
+                f"{TRITON_SCORING_REQUIRED_MARKER}:omega_dim_mismatch:"
+                f"stats={int(score_omega.shape[-1])},runtime={runtime_freq_count}"
+            )
         score_inputs = (
             keys_dense.repeat_interleave(group_size, dim=1).contiguous()
             if use_hf_group_max and group_size > 1
@@ -315,7 +332,7 @@ def build_triattention_selector(
                 key_states=score_inputs,
                 cache_positions=None,
                 head_stats=score_head_stats,
-                omega=compressor.omega,
+                omega=score_omega,
                 offsets=compressor.offsets,
                 freq_scale_sq=score_freq_scale_sq,
                 config=tri_cfg,
@@ -376,6 +393,7 @@ def build_triattention_selector(
         (
             score_head_stats,
             score_freq_scale_sq,
+            score_omega,
             use_hf_group_max,
             group_size,
         ) = _resolve_layer_score_inputs(
@@ -398,6 +416,7 @@ def build_triattention_selector(
                 keys_dense=keys_chunk,
                 score_head_stats=score_head_stats,
                 score_freq_scale_sq=score_freq_scale_sq,
+                score_omega=score_omega,
                 use_hf_group_max=use_hf_group_max,
                 group_size=group_size,
                 round_start=round_start,
@@ -486,6 +505,7 @@ def build_triattention_selector(
         (
             score_head_stats,
             score_freq_scale_sq,
+            score_omega,
             use_hf_group_max,
             group_size,
         ) = _resolve_layer_score_inputs(
@@ -519,6 +539,7 @@ def build_triattention_selector(
                     keys_dense=keys_chunk,
                     score_head_stats=score_head_stats,
                     score_freq_scale_sq=score_freq_scale_sq,
+                    score_omega=score_omega,
                     use_hf_group_max=use_hf_group_max,
                     group_size=group_size,
                     round_start=round_start,
@@ -577,6 +598,7 @@ def build_triattention_selector(
                     keys_dense=keys_chunk,
                     score_head_stats=score_head_stats,
                     score_freq_scale_sq=score_freq_scale_sq,
+                    score_omega=score_omega,
                     use_hf_group_max=use_hf_group_max,
                     group_size=group_size,
                     round_start=round_start,
@@ -829,6 +851,7 @@ def build_triattention_selector(
                 (
                     score_head_stats,
                     score_freq_scale_sq,
+                    score_omega,
                     use_hf_group_max,
                     group_size,
                 ) = _resolve_layer_score_inputs(
@@ -844,6 +867,7 @@ def build_triattention_selector(
                         "runtime_heads": runtime_heads,
                         "score_head_stats": score_head_stats,
                         "score_freq_scale_sq": score_freq_scale_sq,
+                        "score_omega": score_omega,
                         "use_hf_group_max": use_hf_group_max,
                         "group_size": group_size,
                     }
@@ -876,6 +900,7 @@ def build_triattention_selector(
                             keys_dense=keys_chunk,
                             score_head_stats=entry["score_head_stats"],
                             score_freq_scale_sq=entry["score_freq_scale_sq"],
+                            score_omega=entry["score_omega"],
                             use_hf_group_max=entry["use_hf_group_max"],
                             group_size=entry["group_size"],
                             round_start=round_start,
@@ -945,6 +970,7 @@ def build_triattention_selector(
                             keys_dense=keys_chunk,
                             score_head_stats=entry["score_head_stats"],
                             score_freq_scale_sq=entry["score_freq_scale_sq"],
+                            score_omega=entry["score_omega"],
                             use_hf_group_max=entry["use_hf_group_max"],
                             group_size=entry["group_size"],
                             round_start=round_start,


### PR DESCRIPTION
## Summary

Follow-up to #22. This addresses the mixed-head Gemma4 blocker from PR #15 by replacing the pad/slice-to-max strategy with per-layer RoPE frequency bases.

- Keep mixed-head R-KV stats at each layer's native frequency count instead of padding all layers to max width.
- Build per-layer `omega` / `inv_freq` in `TriAttentionCompressor` from `layer_head_dims` / `layer_freq_counts`.
- Store `freq_scale_sq` per layer and thread layer-specific `omega` through the vLLM selector scoring paths.
- Update SGLang scoring to use the compressor's layer-specific omega and validate frequency dimensions.
- Make SGLang validation check every layer instead of stopping after the first layer.
- Add correctness tests proving a 256-d layer scores against the native 256-d RoPE basis, not a sliced 512-d basis.

## Stacking note

This branch is stacked on #22 (`fix: harden R-KV stats loader metadata`). Until #22 lands, GitHub will show that loader-hardening commit in this PR as well. After #22 merges, this branch can be rebased onto `main` to leave only the mixed-head runtime commit.

## Tests

- `pytest triattention/tests/test_gemma4_mixed_head_stats.py triattention/tests/test_rkv_loader_metadata.py -q`
- `python -m py_compile triattention/vllm/core/utils.py triattention/vllm/core/compressor.py triattention/vllm/runtime/selector_hf.py triattention/sglang/stats_loader.py triattention/sglang/scoring_utils.py triattention/tests/test_gemma4_mixed_head_stats.py triattention/tests/test_rkv_loader_metadata.py`
- `git diff --check`